### PR TITLE
Simplify working with infrastructure environments

### DIFF
--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -5,8 +5,3 @@ GitHub Actions is set up to push docker images to the 'fnhsproduction' registry 
 If you want to push to another registry or another cluster then a new set of secrets need to be generated and edited in the GitHub repository.
 
 Follow the instructions here for [secret generation](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-github-action)
-
-# 2. Authenticate with Azure Container Registry (ACR) from Azure Kubernetes Service (AKS)
-
-Once there is a change in registry or cluster you will need to re-establish authentication between ACR and AKS.
-[Configure ACR integration for existing AKS clusters](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration).

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -2,7 +2,7 @@
 
 We use [Terraform](https://www.terraform.io/) to build our environments.
 
-## Installation Instructions
+## Prerequisites
 
 1. Install Terraform:
 
@@ -54,7 +54,7 @@ We use [Terraform](https://www.terraform.io/) to build our environments.
    brew install linkerd
    ```
 
-## Development Environment Setup
+## Development Environment
 
 Infrastructure is set up so that each developer can create their own instance of the environment in Azure,
 as opposed to sharing a staging environment.
@@ -75,18 +75,6 @@ as opposed to sharing a staging environment.
    cd infrastructure/environments/dev
    ```
 
-1. Follow the onscreen instructions to create the terraform.tfvars file.
-
-   The contents of the file should still be printed on the screen.
-
-   Below is an example of what it would likely look like:
-
-   ```hcl-terraform
-   resource_group_name="tfstatejohn"
-   storage_account_name="fnhstfstatedevjohn"
-   USERNAME="john"
-   ```
-
 1. Run Terraform Init using the vars file you just created:
 
    ```bash
@@ -103,6 +91,14 @@ as opposed to sharing a staging environment.
 
    ```bash
    terraform apply
+   ```
+
+1. Give the Kubernetes cluster permissions to pull images from our Docker registry.
+
+   As with step 2, if your name is **John**, your command will be:
+
+   ```bash
+   az aks update -n dev-john -g platform-dev-john --attach-acr "/subscriptions/75173371-c161-447a-9731-f042213a19da/resourceGroups/platform-production/providers/Microsoft.ContainerRegistry/registries/fnhsproduction"
    ```
 
 1. In order to use Kubernetes CLI (kubectl) commands, you need to pull the credentials from the server.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -127,6 +127,36 @@ as opposed to sharing a staging environment.
    terraform destroy
    ```
 
+## Production environment
+
+Production is a long-lived environment. To make changes, follow these steps.
+
+The `ARM_SUBSCRIPTION_ID` environment variable is needed if you're using Azure CLI authentication and production is not your default subscription (which is recommended).
+
+1. Change directory into the dev environment folder:
+
+   ```bash
+   cd infrastructure/environments/production
+   ```
+
+1. Run Terraform Init using the vars file you just created:
+
+   ```bash
+   ARM_SUBSCRIPTION_ID=75173371-c161-447a-9731-f042213a19da terraform init
+   ```
+
+1. Create an execution plan:
+
+   ```bash
+   ARM_SUBSCRIPTION_ID=75173371-c161-447a-9731-f042213a19da terraform plan
+   ```
+
+1. After verifying the plan above, apply changes. The infrastructure will be created in Azure.
+
+   ```bash
+   ARM_SUBSCRIPTION_ID=75173371-c161-447a-9731-f042213a19da terraform apply
+   ```
+
 ## Troubleshooting
 
 1. If an error occurs when applying the terroform it is possible that there is a cached version of an existing terraform set up. You can overcome this by deleting the ./infrastructure/environments/dev/.terraform/ folder and trying again.

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=2.11.0"
+  version = "=2.14.0"
   features {}
   subscription_id = "4a4be66c-9000-4906-8253-6a73f09f418d"
 }

--- a/infrastructure/environments/production/main.tf
+++ b/infrastructure/environments/production/main.tf
@@ -1,11 +1,7 @@
-locals {
-  subscription_id = "75173371-c161-447a-9731-f042213a19da"
-}
-
 provider "azurerm" {
   version = "=2.14.0"
   features {}
-  subscription_id = local.subscription_id
+  subscription_id = "75173371-c161-447a-9731-f042213a19da"
 }
 
 provider "random" {

--- a/infrastructure/environments/production/main.tf
+++ b/infrastructure/environments/production/main.tf
@@ -1,7 +1,11 @@
-provider "azurerm" {
-  version = "=2.11.0"
-  features {}
+locals {
   subscription_id = "75173371-c161-447a-9731-f042213a19da"
+}
+
+provider "azurerm" {
+  version = "=2.14.0"
+  features {}
+  subscription_id = local.subscription_id
 }
 
 provider "random" {
@@ -29,4 +33,11 @@ resource "azurerm_container_registry" "acr" {
   resource_group_name = module.platform.resource_group_name
   location            = var.location
   sku                 = "Basic"
+}
+
+resource "azurerm_role_assignment" "acrpull_cluster" {
+  scope                            = azurerm_container_registry.acr.id
+  role_definition_name             = "AcrPull"
+  principal_id                     = module.platform.cluster_identity_principal_id
+  skip_service_principal_aad_check = true
 }

--- a/infrastructure/modules/platform/outputs.tf
+++ b/infrastructure/modules/platform/outputs.tf
@@ -1,0 +1,7 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.platform.name
+}
+
+output "cluster_identity_principal_id" {
+  value = azurerm_kubernetes_cluster.cluster.kubelet_identity.0.object_id
+}

--- a/infrastructure/modules/platform/variables.tf
+++ b/infrastructure/modules/platform/variables.tf
@@ -5,7 +5,3 @@ variable "environment" {
 variable "location" {
   description = "Azure location"
 }
-
-output "resource_group_name" {
-  value = azurerm_resource_group.platform.name
-}


### PR DESCRIPTION
- The setup-dev-environment.sh script automatically creates the terraform.tfvar file. No need for manual copy-paste.
- Give the production cluster access to the container registry automatically in terraform. No need for a manual command.
- Document how to give the dev cluster access to the container registry. I'm not sure how to automate that, yet.
- Document how to work with the production environment.