### PR TITLE
Fix build trigger for path filters

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: frontend
 
 on:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,7 +4,9 @@
 name: frontend
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
     paths:
       - frontend/**
       - .github/workflows/frontend.yml

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -1,9 +1,9 @@
 name: hello-world
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
+      - master
     paths:
       - hello-world/**
       - .github/workflows/hello-world.yml

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -12,20 +12,12 @@ env:
   IMAGE: fnhsproduction.azurecr.io/platform/hello-world
 
 jobs:
-  build-and-test:
-    name: Build, Test and Deploy
+  ci:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Clone Repo
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           path: platform
-
-      - name: "Login via Azure CLI"
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: "Login to docker"
         uses: azure/docker-login@v1
         with:

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1,7 +1,9 @@
 name: infrastructure
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
     paths:
       - infrastructure/**
       - .github/workflows/infrastructure.yml


### PR DESCRIPTION
When using the path filters, GitHub generates a list of changed files differently for pull request and push triggers (see [docs](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#git-diff-comparisons)):

- Pull request: diff between most recent commit and merge base
- Push: diff between head and base commit

This means our builds were not triggered if the most recent push didn't contain changes to the corresponding files, even if the overall pull request did include changes to them.

This changes the logic to use a pull request based trigger. Pushes itself won't trigger builds now. If this turns out to be an issue, we can enable both.