### PR TITLE
Use a 'Deploy Key' to clone the 'Deployments' repo

### DIFF
--- a/.github/workflows/frontend-branch.yaml
+++ b/.github/workflows/frontend-branch.yaml
@@ -1,7 +1,8 @@
 name: frontend-branch
 
 on:
-  pull_request:
+  # pull_request:
+  push:
     branches:
       - master
     paths:

--- a/.github/workflows/frontend-branch.yaml
+++ b/.github/workflows/frontend-branch.yaml
@@ -1,8 +1,7 @@
 name: frontend-branch
 
 on:
-  # pull_request:
-  push:
+  pull_request:
     branches:
       - master
     paths:

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: FutureNHS/futurenhs-deployments
           path: futurenhs-deployments
-          token: ${{secrets.DEPLOYMENT_TOKEN}}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Copy manifests
         run: |
@@ -56,9 +56,6 @@ jobs:
             cd $GITHUB_WORKSPACE/futurenhs-deployments/frontend
 
             kustomize edit set image $DIGEST
-            # TODO create service account, swap out email, update deployment_token secret
-            git config --local user.email "tracy.wu@red-badger.com"
-            git config --local user.name "FutureNHS CI/CD"
             git add -A
             git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"
 

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -1,7 +1,8 @@
 name: frontend-master
 
 on:
-  push:
+  # push:
+  pull_request:
     branches:
       - master
     paths:

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -57,6 +57,10 @@ jobs:
             cd $GITHUB_WORKSPACE/futurenhs-deployments/frontend
 
             kustomize edit set image $DIGEST
+
+            git config --local user.email "futurenhs-devs@red-badger.com"
+            git config --local user.name "FutureNHS CI/CD"
+
             git add -A
             git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"
 

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -58,7 +58,7 @@ jobs:
 
             kustomize edit set image $DIGEST
 
-            git config --local user.email "futurenhs-devs@red-badger.com"
+            git config --local user.email "tracy.wu@red-badger.com"
             git config --local user.name "FutureNHS CI/CD"
 
             git add -A

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -49,26 +49,27 @@ jobs:
           cp *.yaml $GITHUB_WORKSPACE/futurenhs-deployments/frontend
 
       - name: Update image tag and deploy
-        uses: stefanprodan/kube-tools@v1
-        with:
-          kustomize: 3.5.5
-          command: |
-            set -eux
-            cd $GITHUB_WORKSPACE/futurenhs-deployments/frontend
 
-            kustomize edit set image $DIGEST
+        run: |
+          set -eux
 
-            git config --local user.email "tracy.wu@red-badger.com"
-            git config --local user.name "FutureNHS CI/CD"
+          cd $HOME
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+          cd $GITHUB_WORKSPACE/futurenhs-deployments/frontend
 
-            git add -A
-            git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"
+          $HOME/kustomize edit set image $DIGEST
 
-            declare -i n
-            n=0
-            until [ $n -ge 5 ]
-            do
-              git push && break
-              n+=1
-              git pull --rebase
-            done
+          git config --local user.email "futurenhs-devs@red-badger.com"
+          git config --local user.name "FutureNHS CI/CD"
+
+          git add -A
+          git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"
+
+          declare -i n
+          n=0
+          until [ $n -ge 5 ]
+          do
+            git push && break
+            n+=1
+            git pull --rebase
+          done

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -1,8 +1,7 @@
 name: frontend-master
 
 on:
-  # push:
-  pull_request:
+  push:
     branches:
       - master
     paths:

--- a/.github/workflows/hello-world-master.yaml
+++ b/.github/workflows/hello-world-master.yaml
@@ -56,6 +56,10 @@ jobs:
             cd $GITHUB_WORKSPACE/futurenhs-deployments/hello-world
 
             kustomize edit set image $DIGEST
+
+            git config --local user.email "futurenhs-devs@red-badger.com"
+            git config --local user.name "FutureNHS CI/CD"
+
             git add -A
             git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"
 

--- a/.github/workflows/hello-world-master.yaml
+++ b/.github/workflows/hello-world-master.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: FutureNHS/futurenhs-deployments
           path: futurenhs-deployments
-          token: ${{secrets.DEPLOYMENT_TOKEN}}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Copy manifests
         run: |
@@ -56,9 +56,6 @@ jobs:
             cd $GITHUB_WORKSPACE/futurenhs-deployments/hello-world
 
             kustomize edit set image $DIGEST
-            # TODO create service account, swap out email, update deployment_token secret
-            git config --local user.email "tracy.wu@red-badger.com"
-            git config --local user.name "FutureNHS CI/CD"
             git add -A
             git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"
 

--- a/.github/workflows/hello-world-master.yaml
+++ b/.github/workflows/hello-world-master.yaml
@@ -1,7 +1,8 @@
 name: hello-world-master
 
 on:
-  push:
+  # push:
+  pull_request:
     branches:
       - master
     paths:
@@ -48,19 +49,17 @@ jobs:
           cp *.yaml $GITHUB_WORKSPACE/futurenhs-deployments/hello-world
 
       - name: Update image tag and deploy
-        uses: stefanprodan/kube-tools@v1
-        with:
-          kustomize: 3.5.5
-          command: |
+        run: |
             set -eux
+
+            cd $HOME
+            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
             cd $GITHUB_WORKSPACE/futurenhs-deployments/hello-world
 
-            kustomize edit set image $DIGEST
+            $HOME/kustomize edit set image $DIGEST
 
             git config --local user.email "futurenhs-devs@red-badger.com"
             git config --local user.name "FutureNHS CI/CD"
-
-            ssh -o "StrictHostKeyChecking=no" user@host
 
             git add -A
             git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"

--- a/.github/workflows/hello-world-master.yaml
+++ b/.github/workflows/hello-world-master.yaml
@@ -57,8 +57,10 @@ jobs:
 
             kustomize edit set image $DIGEST
 
-            git config --local user.email "tracy.wu@red-badger.com"
+            git config --local user.email "futurenhs-devs@red-badger.com"
             git config --local user.name "FutureNHS CI/CD"
+
+            ssh -o "StrictHostKeyChecking=no" user@host
 
             git add -A
             git diff-index --quiet HEAD || git commit -am "CI: Update production image for ${TAG}"

--- a/.github/workflows/hello-world-master.yaml
+++ b/.github/workflows/hello-world-master.yaml
@@ -1,8 +1,7 @@
 name: hello-world-master
 
 on:
-  # push:
-  pull_request:
+  push:
     branches:
       - master
     paths:

--- a/.github/workflows/hello-world-master.yaml
+++ b/.github/workflows/hello-world-master.yaml
@@ -57,7 +57,7 @@ jobs:
 
             kustomize edit set image $DIGEST
 
-            git config --local user.email "futurenhs-devs@red-badger.com"
+            git config --local user.email "tracy.wu@red-badger.com"
             git config --local user.name "FutureNHS CI/CD"
 
             git add -A

--- a/.github/workflows/infrastructure-master.yaml
+++ b/.github/workflows/infrastructure-master.yaml
@@ -38,6 +38,9 @@ jobs:
           set -eux
           cd $GITHUB_WORKSPACE/futurenhs-deployments
 
+          git config --local user.email "futurenhs-devs@red-badger.com"
+          git config --local user.name "FutureNHS CI/CD"
+
           git add -A
           git diff-index --quiet HEAD || git commit -am "CI: Update cert-manager and ingress"
 

--- a/.github/workflows/infrastructure-master.yaml
+++ b/.github/workflows/infrastructure-master.yaml
@@ -1,7 +1,8 @@
 name: infrastructure-master
 
 on:
-  push:
+  # push:
+  pull_request:
     branches:
       - master
     paths:
@@ -40,8 +41,6 @@ jobs:
 
           git config --local user.email "futurenhs-devs@red-badger.com"
           git config --local user.name "FutureNHS CI/CD"
-
-          ssh -o "StrictHostKeyChecking=no" user@host
 
           git add -A
           git diff-index --quiet HEAD || git commit -am "CI: Update cert-manager and ingress"

--- a/.github/workflows/infrastructure-master.yaml
+++ b/.github/workflows/infrastructure-master.yaml
@@ -1,8 +1,7 @@
 name: infrastructure-master
 
 on:
-  # push:
-  pull_request:
+  push:
     branches:
       - master
     paths:

--- a/.github/workflows/infrastructure-master.yaml
+++ b/.github/workflows/infrastructure-master.yaml
@@ -38,7 +38,7 @@ jobs:
           set -eux
           cd $GITHUB_WORKSPACE/futurenhs-deployments
 
-          git config --local user.email "futurenhs-devs@red-badger.com"
+          git config --local user.email "tracy.wu@red-badger.com"
           git config --local user.name "FutureNHS CI/CD"
 
           git add -A

--- a/.github/workflows/infrastructure-master.yaml
+++ b/.github/workflows/infrastructure-master.yaml
@@ -38,8 +38,10 @@ jobs:
           set -eux
           cd $GITHUB_WORKSPACE/futurenhs-deployments
 
-          git config --local user.email "tracy.wu@red-badger.com"
+          git config --local user.email "futurenhs-devs@red-badger.com"
           git config --local user.name "FutureNHS CI/CD"
+
+          ssh -o "StrictHostKeyChecking=no" user@host
 
           git add -A
           git diff-index --quiet HEAD || git commit -am "CI: Update cert-manager and ingress"

--- a/.github/workflows/infrastructure-master.yaml
+++ b/.github/workflows/infrastructure-master.yaml
@@ -23,6 +23,7 @@ jobs:
           repository: FutureNHS/futurenhs-deployments
           path: futurenhs-deployments
           token: ${{secrets.DEPLOYMENT_TOKEN}}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Copy manifests
         run: |
@@ -37,9 +38,6 @@ jobs:
           set -eux
           cd $GITHUB_WORKSPACE/futurenhs-deployments
 
-          # TODO create service account, swap out email, update deployment_token secret
-          git config --local user.email "tracy.wu@red-badger.com"
-          git config --local user.name "FutureNHS CI/CD"
           git add -A
           git diff-index --quiet HEAD || git commit -am "CI: Update cert-manager and ingress"
 

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -1,7 +1,16 @@
-# 1. Setting registry and cluster
+# 1. Setting registry and cluster.
 
 GitHub Actions is set up to push docker images to the 'fnhsproduction' registry in the 'production' cluster.
 
 If you want to push to another registry or another cluster then a new set of secrets need to be generated and edited in the GitHub repository.
 
-Follow the instructions here for [secret generation](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-github-action)
+Follow the instructions here for [secret generation](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-github-action).
+
+# 2.  Creating a Deploy Key.
+The [Deploy Key](https://developer.github.com/v3/guides/managing-deploy-keys/) gives our CI server read and write access to the [Deployments repo](https://github.com/FutureNHS/futurenhs-deployments), which it needs in order to clone the repo and update the disc image tag.
+
+## Steps to create and use the Deploy Key.
+- Create an SSH key using `ssh-keygen -t rsa -b 4096 -C "futurenhs-devs@red-badger.com"`.
+- When asked, leave the passphrase empty.
+- Add the public part of the key to the 'Deployments' repo (settings/deploy-keys).
+- Add the private part of the key to the ‘Platform’ repo as a secret (settings/secrets).


### PR DESCRIPTION
![sergey-raikin-gvU2BW7EXQE-unsplash](https://user-images.githubusercontent.com/13286587/86792203-277c3180-c062-11ea-9e9e-f3fcd5686fe5.jpg)

[Ticket](https://airtable.com/tblgtzV3sSwquTkIa/viw8ZHoNqvSvl62lt/recdG8LU95dtv2g1R?blocks=hide)

## Acceptance Criteria

- [x] Having removed the current token and replaced with the 'Deploy Key', we are successfully able to clone the 'Deployments repository from CI.

## Things
- The deploy key is an SSH key generated using `ssh-keygen -t rsa -b 4096 -C "futurenhs-devs@red-badger.com"`
- The public part of the key is added to the 'Deployments' repo (settings/deploy-keys).
- The private part of the key is added to the ‘Platform’ repo as a secret (settings/secrets), and is used within the ‘Platform’ workflow to clone the ‘Deployments’ repo.  
- Once cloned, the ‘Deployments’ repo is then be updated with the new disc image tag(s).

Once complete, the 'DEPLOYMENT_TOKEN' can be removed from settings/secrets

## Testing information

- Is there any special setup required? 

Good question - i guess, as long as a master build is able to clone the 'Deployments' repo succesfully then we have succeeded. When in development, this was tested by changing master workflows to run on PR update rather than push to master.

