### PR TITLE
revert ingress change

### DIFF
--- a/infrastructure/kubernetes/ingress/prod/ingress-hello-world.yaml
+++ b/infrastructure/kubernetes/ingress/prod/ingress-hello-world.yaml
@@ -7,12 +7,13 @@ metadata:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
     - host: fnhs.westeurope.cloudapp.azure.com
       http:
         paths:
-          - path: /hello
+          - path: /hello-world(/|$)(.*)
             backend:
               serviceName: hello-world
               servicePort: 80


### PR DESCRIPTION
Currently nginx ingress is broken for the hello-world service. This PR reverts it to the last known working version.