### PR TITLE
idempotent `CLEAN=localstate create-dev-environment.sh`

### DIFF
--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -10,12 +10,12 @@ if [ "$NAME" != "${NAME//[^a-z]/-}" ]; then
 fi
 
 # We might want to write a OVERWRITE=full version later that does a terraform destroy etc.
-OVERWRITE="${OVERWRITE:-nothing}"
-if [[ "$OVERWRITE" != "localfiles" && "$OVERWRITE" != "justdotterraform" && "$OVERWRITE" != "nothing" ]]; then
+OVERWRITE="${OVERWRITE:-forbidden}"
+if [[ "$OVERWRITE" != "localfiles" && "$OVERWRITE" != "justdotterraform" && "$OVERWRITE" != "forbidden" ]]; then
 	echo "Unexpected value for OVERWRITE environment variable: '$OVERWRITE'"
 	echo "Use OVERWRITE=localfiles to clean your local terraform.tfvars and .terraform."
 	echo "Use OVERWRITE=justdotterraform to clean just .terraform, but leave your terraform.tfvars alone."
-	echo "Use OVERWRITE=nothing (the default) if you are using a clean envionment."
+	echo "Use OVERWRITE=forbidden (the default) if you are using a clean envionment and want to abort if anything is unclean."
 	exit 1
 fi
 
@@ -89,7 +89,7 @@ setup_terraform() {
 		--account-key "$ACCESS_KEY" \
 		--output none
 
-	if [ "$OVERWRITE" = "localfiles" ] || [ ! -f "$DEV_CONFIG_FILE" ]; then
+	if [ ! -f "$DEV_CONFIG_FILE" ]; then
 		cat >"$DEV_CONFIG_FILE" <<EOF
 resource_group_name="$RESOURCE_GROUP_NAME"
 storage_account_name="$STORAGE_ACCOUNT_NAME"

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -36,7 +36,13 @@ setup_terraform() {
 		rm -r $TERRAFORM_DIR
 	elif [ -f "$DEV_CONFIG_FILE" ]; then
 		echo "File $DEV_CONFIG_FILE already exists."
-		echo "If you want to initialize your environment again, please delete the file and rerun this script."
+		echo "If you want to initialize your environment again, please delete the file and rerun this script,"
+		echo "or run:"
+		echo ""
+		echo "    OVERWRITE=localfiles $0 $NAME"
+		echo "or:"
+		echo "    OVERWRITE=justdotterraform $0 $NAME"
+		echo ""
 		exit 1
 	elif [ -d "$TERRAFORM_DIR" ]; then
 		echo "Folder $TERRAFORM_DIR already exists."
@@ -86,8 +92,8 @@ ip_whitelist_postgresql={"$NAME" = $(dig TXT +short o-o.myaddr.l.google.com @ns1
 EOF
 	fi
 
-  # terraform init is idempotent, so we might as well run it for the user.
-  cd $REPO_ROOT/infrastructure/environments/dev && terraform init -backend-config=terraform.tfvars
+	# terraform init is idempotent, so we might as well run it for the user.
+	cd $REPO_ROOT/infrastructure/environments/dev && terraform init -backend-config=terraform.tfvars
 
 	echo "Your dev terraform environment is ready to go. To initialize run:"
 	echo "("

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -9,13 +9,13 @@ if [ "$NAME" != "${NAME//[^a-z]/-}" ]; then
 	exit 1
 fi
 
-# We might want to write a CLEAN=full version later that does a terraform destroy etc.
-CLEAN="${CLEAN:-check}"
-if [[ "$CLEAN" != "local" && "$CLEAN" != "localstate" && "$CLEAN" != "check" ]]; then
-	echo "Unexpected value for CLEAN environment variable: '$CLEAN'"
-	echo "Use CLEAN=local to clean your local files and configs."
-	echo "Use CLEAN=localstate to clean just .terraform, but keep your terraform.tfvars config."
-	echo "Use CLEAN=check (the default) if you are using a clean envionment."
+# We might want to write a OVERWRITE=full version later that does a terraform destroy etc.
+OVERWRITE="${OVERWRITE:-nothing}"
+if [[ "$OVERWRITE" != "localfiles" && "$OVERWRITE" != "justdotterraform" && "$OVERWRITE" != "nothing" ]]; then
+	echo "Unexpected value for OVERWRITE environment variable: '$OVERWRITE'"
+	echo "Use OVERWRITE=localfiles to clean your local terraform.tfvars and .terraform."
+	echo "Use OVERWRITE=justdotterraform to clean just .terraform, but leave your terraform.tfvars alone."
+	echo "Use OVERWRITE=nothing (the default) if you are using a clean envionment."
 	exit 1
 fi
 
@@ -30,9 +30,9 @@ setup_terraform() {
 	STORAGE_ACCOUNT_NAME=fnhstfstatedev$NAME
 	CONTAINER_NAME=tfstate
 
-	if [ "$CLEAN" = "local" ]; then
+	if [ "$OVERWRITE" = "localfiles" ]; then
 		rm -r $DEV_CONFIG_FILE $TERRAFORM_DIR
-	elif [ "$CLEAN" = "localstate" ]; then
+	elif [ "$OVERWRITE" = "justdotterraform" ]; then
 		rm -r $TERRAFORM_DIR
 	elif [ -f "$DEV_CONFIG_FILE" ]; then
 		echo "File $DEV_CONFIG_FILE already exists."
@@ -77,7 +77,7 @@ setup_terraform() {
 		--account-key "$ACCESS_KEY" \
 		--output none
 
-	if [ "$CLEAN" = "localstate" ]; then
+	if [ "$OVERWRITE" = "localfiles" ] || [ ! -f "$DEV_CONFIG_FILE" ]; then
 		cat >"$DEV_CONFIG_FILE" <<EOF
 resource_group_name="$RESOURCE_GROUP_NAME"
 storage_account_name="$STORAGE_ACCOUNT_NAME"

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -86,10 +86,12 @@ ip_whitelist_postgresql={"$NAME" = $(dig TXT +short o-o.myaddr.l.google.com @ns1
 EOF
 	fi
 
+  # terraform init is idempotent, so we might as well run it for the user.
+  cd $REPO_ROOT/infrastructure/environments/dev && terraform init -backend-config=terraform.tfvars
+
 	echo "Your dev terraform environment is ready to go. To initialize run:"
 	echo "("
 	echo "    cd $REPO_ROOT/infrastructure/environments/dev &&"
-	echo "    terraform init -backend-config=terraform.tfvars &&"
 	echo "    terraform apply -target module.platform &&"
 	echo "    terraform apply"
 	echo ")"

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -47,6 +47,12 @@ setup_terraform() {
 	elif [ -d "$TERRAFORM_DIR" ]; then
 		echo "Folder $TERRAFORM_DIR already exists."
 		echo "If you want to initialize your environment again, please delete that directory and rerun this script."
+		echo "or run:"
+		echo ""
+		echo "    OVERWRITE=localfiles $0 $NAME"
+		echo "or:"
+		echo "    OVERWRITE=justdotterraform $0 $NAME"
+		echo ""
 		exit 1
 	fi
 


### PR DESCRIPTION
After applying this patch, `CLEAN=localstate ./create-dev-environment.sh david` will be idempotent: you can safely run it as many times as you want.

Also, `./create-dev-environment.sh david` will now also flag up if you have a .terraform dir lying around.

I have used environment variables because parsing flags is harder that I can be bothered with, and people should get used to using environment variables anyway, because that's how 12-factor apps are configured.