### PR TITLE
Ensure all developers have access to key vaults

### DIFF
--- a/infrastructure/environments/shared-dev/sealed-secret.tf
+++ b/infrastructure/environments/shared-dev/sealed-secret.tf
@@ -28,15 +28,10 @@ resource "azurerm_key_vault" "vault" {
     // See https://portal.azure.com/#blade/Microsoft_AAD_IAM/GroupDetailsMenuBlade/Overview/groupId/b06ebd00-f52c-4e82-ac88-0520f4320fee
     object_id = "b06ebd00-f52c-4e82-ac88-0520f4320fee"
 
-    key_permissions = [
-      "create",
-      "get",
-    ]
-
     secret_permissions = [
-      "set",
-      "get",
-      "delete",
+      "Set",
+      "Get",
+      "Delete",
     ]
   }
 

--- a/infrastructure/modules/analytics/main.tf
+++ b/infrastructure/modules/analytics/main.tf
@@ -21,12 +21,9 @@ resource "azurerm_key_vault" "secret_vault" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "Create",
-      "Get",
-    ]
+    // This object_id relates to the FutureNHS Developers Group ID. 
+    // See https://portal.azure.com/#blade/Microsoft_AAD_IAM/GroupDetailsMenuBlade/Overview/groupId/b06ebd00-f52c-4e82-ac88-0520f4320fee
+    object_id = "b06ebd00-f52c-4e82-ac88-0520f4320fee"
 
     secret_permissions = [
       "Set",


### PR DESCRIPTION
Before this, only the person applying Terraform will get permissions to analytics secrets. If another person then tries to apply Terraform, they will get the following error:

    Error: Error making Read request on Azure KeyVault Secret synapse-password: keyvault.BaseClient#GetSecret: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="The user, group or application 'appid=XXX;oid=XXX;numgroups=1;iss=https://sts.windows.net/XXX/' does not have secrets get permission on key vault 'fnhs-analytics-XXX;location=westeurope'. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125287" InnerError={"code":"AccessDenied"}

This gives the FutureNHS Developers AAD group permissions instead, which means all core developers are able to apply Terraform.