### PR TITLE
make yarn dev use https

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# SSL certificates
+localhost*.pem
+
 # dependencies
 /node_modules
 /.pnp

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,10 +6,18 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 Frontend development server relies on some services that are available in the development cluster. Specifically, it calls out to the hello-world service when doing server-side rendering, and also proxies `/hello/*` to `http://hello-world.hello-world/hello/*` like how our nginx ingress does in production.
 
-In order to set up a development cluster, see ../infrastructure/README.md. Once your development cluster is set up, you should run this to make the cluster's services available for local development:
+In order to set up a development cluster, see ../infrastructure/README.md.
+
+You will also need to generate some certificates, because our login cookies are https only (even in dev).
 
 ```bash
-sudo kubefwd services -n hello-world -n frontend -n argocd
+yarn mkcert
+```
+
+Once your development cluster is set up, you should run this to make the cluster's services available for local development:
+
+```bash
+sudo kubefwd services -n hello-world -n frontend -n argocd -n hello-world -n kratos
 ```
 
 Once that is running, start the dev server like this:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_OPTIONS='--require ./tracing.js' next start",
     "test": "jest",
     "lint": "yarn eslint",
-    "clean": "rm -rf .next"
+    "clean": "rm -rf .next",
+    "mkcert": "brew install mkcert nss && mkcert -install && mkcert localhost 127.0.0.1 ::1"
   },
   "dependencies": {
     "@azure/monitor-opentelemetry-exporter": "^1.0.0-preview.3",

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -2,8 +2,11 @@
 /// only be used for local development.
 /// https://github.com/vercel/next.js/tree/master/examples/with-custom-reverse-proxy
 /* eslint-disable no-console */
+const fs = require("fs");
 const express = require("express");
+const https = require("https");
 const next = require("next");
+const process = require("process");
 
 const devProxy = {
   "/hello": {
@@ -18,7 +21,7 @@ const devProxy = {
   // another one that hits ory/kratos refer to http-proxy-middleware docs to understand the format
 };
 
-const port = parseInt(process.env.PORT, 10) || 4455;
+const port = parseInt(process.env.PORT, 10) || 4433;
 if (process.env.NODE_ENV !== "development") {
   console.error(
     "This server should only be used by `yarn dev`, and should never be used in production."
@@ -26,33 +29,44 @@ if (process.env.NODE_ENV !== "development") {
   process.exit(1);
 }
 
-const app = next({
+try {
+  var httpsOptions = {
+    key: fs.readFileSync("./localhost+2-key.pem"),
+    cert: fs.readFileSync("./localhost+2.pem"),
+  };
+} catch (error) {
+  console.warn("Please run `yarn mkcert` to generate localhost*.pem");
+  process.exit(1);
+}
+
+const nextApp = next({
   dir: ".", // base directory where everything is, could move to src later
   dev: true,
 });
 
-const handle = app.getRequestHandler();
-
-let server;
-app
+nextApp
   .prepare()
-  .then(() => {
-    server = express();
+  .then(async () => {
+    // This is an express app.
+    const expressApp = express();
+
+    const server = https.createServer(httpsOptions, expressApp);
 
     // Set up the proxy.
     const { createProxyMiddleware } = require("http-proxy-middleware");
     Object.keys(devProxy).forEach(function (context) {
-      server.use(context, createProxyMiddleware(devProxy[context]));
+      expressApp.use(context, createProxyMiddleware(devProxy[context]));
     });
 
     // Default catch-all handler to allow Next.js to handle all other routes
-    server.all("*", (req, res) => handle(req, res));
+    const handle = nextApp.getRequestHandler();
+    expressApp.all("*", (req, res) => handle(req, res));
 
     server.listen(port, (err) => {
       if (err) {
         throw err;
       }
-      console.log(`> Ready on http://localhost:${port} [development]`);
+      console.log(`> Ready on https://localhost:${port} [development]`);
     });
   })
   .catch((err) => {

--- a/infrastructure/dev-overlay-variables.json
+++ b/infrastructure/dev-overlay-variables.json
@@ -5,7 +5,7 @@
       "Should be of the form 'pr-$LOCALBRANCH'"],
     "KRATOS_WEB_ROOT": [
       "Set this to 'https://fnhs-dev-$YOURNAME.westeurope.cloudapp.azure.com' for testing your cluster",
-      "or 'http://localhost:4455' for local testing.",
+      "or 'https://localhost:4433' for local testing.",
       "This is a work-around until https://github.com/ory/kratos/pull/617 gets finished and released."
     ],
     "INSTRUMENTATION_KEY": [

--- a/infrastructure/kubernetes/kratos/base/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/base/kratos.yaml
@@ -66,12 +66,7 @@ spec:
           image: "oryd/kratos:v0.4.6"
           imagePullPolicy: IfNotPresent
           command: ["kratos"]
-          args: [
-              "serve",
-              "all",
-              "--config",
-              "/etc/config/config.yaml",
-            ]
+          args: ["serve", "all", "--config", "/etc/config/config.yaml"]
           volumeMounts:
             - name: kratos-config-volume
               mountPath: /etc/config

--- a/infrastructure/kubernetes/kratos/base/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/base/kratos.yaml
@@ -69,9 +69,6 @@ spec:
           args: [
               "serve",
               "all",
-              # FIXME remove the --dev flag somehow. Might be possible to make the localhost dev server be secure + self-signed?
-              # https://www.ory.sh/kratos/docs/debug/csrf/#ory-kratos-running-over-http-without-dev-mode-enabled
-              "--dev",
               "--config",
               "/etc/config/config.yaml",
             ]

--- a/infrastructure/kubernetes/kratos/dev-template/config.yaml
+++ b/infrastructure/kubernetes/kratos/dev-template/config.yaml
@@ -16,6 +16,10 @@ selfservice:
       enabled: true
 
   flows:
+    recovery:
+      enabled: true
+      ui_url: $KRATOS_WEB_ROOT/recovery
+
     logout:
       after:
         default_browser_return_url: $KRATOS_WEB_ROOT/auth/login

--- a/infrastructure/kubernetes/kratos/production/config.yaml
+++ b/infrastructure/kubernetes/kratos/production/config.yaml
@@ -16,6 +16,10 @@ selfservice:
       enabled: true
 
   flows:
+    recovery:
+      enabled: true
+      ui_url: https://fnhs.westeurope.cloudapp.azure.com/recovery
+
     logout:
       after:
         default_browser_return_url: https://fnhs.westeurope.cloudapp.azure.com/auth/login

--- a/infrastructure/scripts/new-kratos-user.sh
+++ b/infrastructure/scripts/new-kratos-user.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eux0 pipefail
+
+ENVIRONMENT="${1:?"Please specify your email as the first parameter, e.g. jane.doe@red-badger.com"}"
+
+
+TEMPLATE='{
+  "traits": {
+    "email": "EMAIL"
+  }
+}'
+
+EMAIL=david.laban+curl@red-badger.com
+
+curl --header "Content-Type: application/json" \
+  --request POST \
+  --data "$(echo $TEMPLATE | sed s/EMAIL/$EMAIL/g)" \
+  http://kratos-admin.kratos/identities

--- a/infrastructure/scripts/new-kratos-user.sh
+++ b/infrastructure/scripts/new-kratos-user.sh
@@ -4,7 +4,6 @@ set -eux0 pipefail
 
 ENVIRONMENT="${1:?"Please specify your email as the first parameter, e.g. jane.doe@red-badger.com"}"
 
-
 TEMPLATE='{
   "traits": {
     "email": "EMAIL"
@@ -14,6 +13,6 @@ TEMPLATE='{
 EMAIL=david.laban+curl@red-badger.com
 
 curl --header "Content-Type: application/json" \
-  --request POST \
-  --data "$(echo $TEMPLATE | sed s/EMAIL/$EMAIL/g)" \
-  http://kratos-admin.kratos/identities
+	--request POST \
+	--data "$(echo $TEMPLATE | sed s/EMAIL/$EMAIL/g)" \
+	http://kratos-admin.kratos/identities


### PR DESCRIPTION
Outstanding issues:

- [ ] Once we remove the --dev option, there is no way to bootstrap users into the system. This is because the example app doesn't use https, and so won't be able to use any of the cookies that kratos sends.
  - this is part of https://airtable.com/tblgtzV3sSwquTkIa/viwKLAjXIngcG7U7E/recLaXEtzIwsLMJXb?blocks=hide