### PR TITLE
Set git user/email earlier in branch builds

### DIFF
--- a/.github/workflows/frontend-branch.yaml
+++ b/.github/workflows/frontend-branch.yaml
@@ -41,6 +41,8 @@ jobs:
         working-directory: futurenhs-deployments
         run: |
           set -eux
+          git config --local user.email "futurenhs-devs@red-badger.com"
+          git config --local user.name "FutureNHS CI/CD"
           if git fetch --unshallow origin pr-$GITHUB_HEAD_REF master ; then
             git checkout origin/pr-$GITHUB_HEAD_REF -b pr-$GITHUB_HEAD_REF
             git merge origin/master --strategy=recursive --strategy-option=ours
@@ -69,9 +71,6 @@ jobs:
         working-directory: futurenhs-deployments
         run: |
           set -eux
-
-          git config --local user.email "futurenhs-devs@red-badger.com"
-          git config --local user.name "FutureNHS CI/CD"
 
           git add -A
           # TODO: can we make this commit message reflect the message at the tip of the platform repo?

--- a/.github/workflows/hello-world-branch.yaml
+++ b/.github/workflows/hello-world-branch.yaml
@@ -42,6 +42,8 @@ jobs:
         working-directory: futurenhs-deployments
         run: |
           set -eux
+          git config --local user.email "futurenhs-devs@red-badger.com"
+          git config --local user.name "FutureNHS CI/CD"
           if git fetch --unshallow origin pr-$GITHUB_HEAD_REF master ; then
             git checkout origin/pr-$GITHUB_HEAD_REF -b pr-$GITHUB_HEAD_REF
             git merge origin/master --strategy=recursive --strategy-option=ours
@@ -69,9 +71,6 @@ jobs:
         working-directory: futurenhs-deployments
         run: |
           set -eux
-
-          git config --local user.email "futurenhs-devs@red-badger.com"
-          git config --local user.name "FutureNHS CI/CD"
 
           git add -A
           # TODO: can we make this commit message reflect the message at the tip of the platform repo?

--- a/.github/workflows/infrastructure-branch.yaml
+++ b/.github/workflows/infrastructure-branch.yaml
@@ -44,6 +44,8 @@ jobs:
         working-directory: futurenhs-deployments
         run: |
           set -eux
+          git config --local user.email "futurenhs-devs@red-badger.com"
+          git config --local user.name "FutureNHS CI/CD"
           if git fetch --unshallow origin pr-$GITHUB_HEAD_REF master ; then
             git checkout origin/pr-$GITHUB_HEAD_REF -b pr-$GITHUB_HEAD_REF
             git merge origin/master --strategy=recursive --strategy-option=ours
@@ -65,9 +67,6 @@ jobs:
         working-directory: futurenhs-deployments
         run: |
           set -eux
-
-          git config --local user.email "futurenhs-devs@red-badger.com"
-          git config --local user.name "FutureNHS CI/CD"
 
           git add -A
           # TODO: can we make this commit message reflect the message at the tip of the platform repo?


### PR DESCRIPTION
In order to create a merge commt, git needs to have a user.name/user.email. This means we need to specify them a bit earlier in the branch builds.