### PR TITLE
Send emails fixes

### DIFF
--- a/infrastructure/kubernetes/kratos/base/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/base/kratos.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       initContainers:
         - name: kratos-automigrate
-          image: "fnhsproduction.azurecr.io/kratos:v0.4.6-alpha.1-98-gc13b1838-merged-with-uri-reference-for-ui_url-ga42cd2bd"
+          image: "fnhsproduction.azurecr.io/kratos:v0.4.6-alpha.1-106-gbcfb2793"
           imagePullPolicy: IfNotPresent
           command: ["kratos"]
           args:
@@ -110,7 +110,7 @@ spec:
                 path: courier-templates/recovery/invalid/email.subject.gotmpl
       containers:
         - name: kratos
-          image: "fnhsproduction.azurecr.io/kratos:v0.4.6-alpha.1-98-gc13b1838-merged-with-uri-reference-for-ui_url-ga42cd2bd"
+          image: "fnhsproduction.azurecr.io/kratos:v0.4.6-alpha.1-106-gbcfb2793"
           imagePullPolicy: IfNotPresent
           command: ["kratos"]
           args: [

--- a/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
@@ -11,3 +11,5 @@ spec:
           env:
             - name: COURIER_SMTP_FROM_ADDRESS
               value: "no-reply@login.fnhs-dev-$NAME.westeurope.cloudapp.azure.com"
+            - name: LOG_LEAK_SENSITIVE_VALUES
+              value: true

--- a/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
@@ -13,3 +13,7 @@ spec:
               value: "no-reply@login.fnhs-dev-$NAME.westeurope.cloudapp.azure.com"
             - name: LOG_LEAK_SENSITIVE_VALUES
               value: true
+            - name: SELFSERVICE_DEFAULT_BROWSER_RETURN_URL
+              value: /dev
+            - name: LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL
+              value: /dev?logged_out=yes_you_should_now_be_logged_out

--- a/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
@@ -15,5 +15,5 @@ spec:
               value: "true"
             - name: SELFSERVICE_DEFAULT_BROWSER_RETURN_URL
               value: "/dev"
-            - name: LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL
+            - name: SELFSERVICE_FLOWS_LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL
               value: "/dev?logged_out=yes_you_should_now_be_logged_out"

--- a/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
+++ b/infrastructure/kubernetes/kratos/dev-template/kratos.yaml
@@ -12,8 +12,8 @@ spec:
             - name: COURIER_SMTP_FROM_ADDRESS
               value: "no-reply@login.fnhs-dev-$NAME.westeurope.cloudapp.azure.com"
             - name: LOG_LEAK_SENSITIVE_VALUES
-              value: true
+              value: "true"
             - name: SELFSERVICE_DEFAULT_BROWSER_RETURN_URL
-              value: /dev
+              value: "/dev"
             - name: LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL
-              value: /dev?logged_out=yes_you_should_now_be_logged_out
+              value: "/dev?logged_out=yes_you_should_now_be_logged_out"

--- a/infrastructure/scripts/install-argo-cd.sh
+++ b/infrastructure/scripts/install-argo-cd.sh
@@ -13,7 +13,7 @@ if [ "$ENVIRONMENT" != "$CURRENT_CONTEXT" ]; then
 	echo "You want to deploy to:   $ENVIRONMENT"
 	echo "Your current content is: $CURRENT_CONTEXT"
 	echo "Please change your current context using:"
-	echo "    kubectl config use-context $ENVIRONMENT'"
+	echo "    kubectl config use-context $ENVIRONMENT"
 	echo "or"
 	echo "    az account set --subscription \$SUBSCRIPTION_ID && az aks get-credentials --resource-group=platform-$ENVIRONMENT --name=$ENVIRONMENT"
 	echo "and try again."


### PR DESCRIPTION
These are the last few items that feel like they're actually in scope for ["Ability to send emails"](https://airtable.com/tblgtzV3sSwquTkIa/viw8ZHoNqvSvl62lt/recVU3BGN3UCVbe1w?blocks=hide). The rest have been punted to ["Register users (service team)"](https://airtable.com/tblgtzV3sSwquTkIa/viw8ZHoNqvSvl62lt/recHKHxau7aAUsB8u?blocks=hide).


## Acceptance Criteria
* `infrastructure/scripts/new-kratos-user.sh dev-david david.laban+dev@red-badger.com` works.
* `infrastructure/scripts/new-kratos-user.sh production david.laban+prod@red-badger.com` :
  * gives the right password-reset link
  * still works if the user has already been created
* Docker image for kratos is built from an actual commit from their master branch, rather than a crazy merge that I did myself.