### PR TITLE
Automatic updated using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically
+version: 2
+updates:
+  # GitHub actions used in .github/workflows/
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  # Global Prettier
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  # Frontend
+  - package-ecosystem: docker
+    directory: /frontend/
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /frontend/
+    schedule:
+      interval: weekly
+  # Hello World
+  - package-ecosystem: cargo
+    directory: /hello-world/
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /hello-world/
+    schedule:
+      interval: weekly
+  # Test
+  - package-ecosystem: npm
+    directory: /test/
+    schedule:
+      interval: weekly
+  # Workspace Service
+  - package-ecosystem: cargo
+    directory: /workspace-service/
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /workspace-service/
+    schedule:
+      interval: weekly


### PR DESCRIPTION
What do you all think about having automated dependency updates using Dependabot?

- It supports everything we need at the moment: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
- It creates one PR per dependency update, which can be quite noisy. We should update everyone once manually before we merge, otherwise we're going to get flooded.
- There is no way to automerge, unless we have a separate merge bot. I also tested Renovate separately. But I found the configuration a bit harder and the integration with GitHub not as good.