### PR TITLE
Cache sqlx

### DIFF
--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,11 +36,17 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Cache sqlx
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/sqlx
+          key: 0.1.0-beta.1
       - name: Run DB migrations on test database
         working-directory: futurenhs-platform/workspace-service
         run: |
           set -e
-          cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
+          command -v sqlx || cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
       - name: "Build & Push image"

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -37,11 +37,17 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Cache sqlx
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/sqlx
+          key: 0.1.0-beta.1
       - name: Run DB migrations on test database
         working-directory: futurenhs-platform/workspace-service
         run: |
           set -e
-          cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
+          command -v sqlx || cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
       - name: "Build & Push image"


### PR DESCRIPTION
[Ticket](https://airtable.com/tblgtzV3sSwquTkIa/viw8ZHoNqvSvl62lt/recMsd5a69XusQz6p?blocks=hide)

Currently we have to recompile sqlx each build.  This PR caches it via a github action, to speed up the build.

## Acceptance Criteria

- [x] SQLX build is cached.