### PR TITLE
Remove Dockerfile database dependency

### DIFF
--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -e
           command -v sqlx || cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
-          export DATABASE_URL=postgres://postgres:postgres@localhost:5432
+          # export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
       - name: "Build & Push image"
         working-directory: futurenhs-platform/workspace-service

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -41,14 +41,16 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/sqlx
+            ~/.cargo/bin/cargo-sqlx
           key: 0.1.0-beta.1
       - name: Run DB migrations on test database
         working-directory: futurenhs-platform/workspace-service
         run: |
           set -e
-          command -v sqlx || cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
+          command -v cargo-sqlx || cargo install --git https://github.com/frigus02/sqlx --rev 106a6a83952bfc0e3316d54f99d865e469dcc15a sqlx-cli
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
+          cargo sqlx prepare --check -- --bin workspace_service
       - name: "Build & Push image"
         working-directory: futurenhs-platform/workspace-service
         run: |

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -e
           command -v sqlx || cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
-          # export DATABASE_URL=postgres://postgres:postgres@localhost:5432
+          export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
       - name: "Build & Push image"
         working-directory: futurenhs-platform/workspace-service

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -48,9 +48,10 @@ jobs:
         working-directory: futurenhs-platform/workspace-service
         run: |
           set -e
-          command -v sqlx || cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
+          command -v cargo-sqlx || cargo install --git https://github.com/frigus02/sqlx --rev 106a6a83952bfc0e3316d54f99d865e469dcc15a sqlx-cli
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
+          cargo sqlx prepare --check -- --bin workspace_service
       - name: "Build & Push image"
         run: |
           cd $GITHUB_WORKSPACE/futurenhs-platform/workspace-service

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/sqlx
+            ~/.cargo/bin/cargo-sqlx
           key: 0.1.0-beta.1
       - name: Run DB migrations on test database
         working-directory: futurenhs-platform/workspace-service

--- a/workspace-service/Cargo.lock
+++ b/workspace-service/Cargo.lock
@@ -858,6 +858,9 @@ name = "either"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2474,6 +2477,7 @@ dependencies = [
  "parking_lot 0.11.0",
  "percent-encoding",
  "rand",
+ "serde",
  "sha-1 0.9.1",
  "sha2",
  "smallvec",
@@ -2495,8 +2499,11 @@ dependencies = [
  "either",
  "futures 0.3.5",
  "heck",
+ "hex 0.4.2",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx-core",
  "sqlx-rt",

--- a/workspace-service/Cargo.toml
+++ b/workspace-service/Cargo.toml
@@ -8,7 +8,7 @@ dotenv = "0.15.0"
 futures = "0.3.5"
 opentelemetry-application-insights = "0.4.0"
 opentelemetry = "0.8.0"
-sqlx = { git = "https://github.com/frigus02/sqlx", rev = "106a6a83952bfc0e3316d54f99d865e469dcc15a", default-features = false, features = [ "runtime-tokio", "macros", "migrate", "postgres", "tls","uuid" ]  }
+sqlx = { git = "https://github.com/frigus02/sqlx", rev = "106a6a83952bfc0e3316d54f99d865e469dcc15a", default-features = false, features = [ "runtime-tokio", "macros", "migrate", "offline", "postgres", "tls","uuid" ]  }
 tide = "0.13.0"
 tokio = { version = "0.2.22", features = ["macros", "time", "rt-core", "stream"] }
 tracing = { version = "0.1.19", features = ["attributes"] }

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /usr/src/workspace-service
 COPY Cargo.toml .
 COPY Cargo.lock .
 
-ENV DATABASE_URL=$DATABASE_URL
 ENV SQLX_OFFLINE=true
 
 # Layer hack: Build an empty program to compile dependencies and place on their own layer.

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -8,9 +8,8 @@ WORKDIR /usr/src/workspace-service
 COPY Cargo.toml .
 COPY Cargo.lock .
 
-# IP Address tells docker to talk to host
-ARG DATABASE_URL=postgres://postgres:postgres@172.17.0.1:5432
 ENV DATABASE_URL=$DATABASE_URL
+ENV SQLX_OFFLINE=true
 
 # Layer hack: Build an empty program to compile dependencies and place on their own layer.
 # This cuts down build time
@@ -39,6 +38,7 @@ FROM build-context AS build
 
 COPY ./src ./src
 COPY sql ./sql
+COPY sqlx-data.json .
 COPY ./migrations ./migrations
 
 RUN cargo clippy --release -- -D warnings && cargo test --release && cargo build --release

--- a/workspace-service/README.md
+++ b/workspace-service/README.md
@@ -5,6 +5,7 @@
 The API is built with [Rust](https://www.rust-lang.org/), using a web server crate called [tide](https://github.com/http-rs/tide), and the source code can be seen in [./src/main.rs](./src/main.rs).
 
 1. Install the rust toolchain (see https://www.rust-lang.org/learn/get-started)
+1. Install the [SQLx CLI](https://github.com/launchbadge/sqlx/tree/master/sqlx-cli) so that you use database in local development (ie migrate run, `prepare` when you change the schema)
 1. Run the tests to make sure everything is set up correctly: `cargo test`
 1. Run locally: `cargo run`
 1. Build a Docker image `make docker-build`

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -1,0 +1,132 @@
+{
+  "db": "PostgreSQL",
+  "3d81af220cbcb1648d4caa7f67852acfff7a96a51118699a5db7cdfaa6ce424f": {
+    "query": "INSERT INTO workspace (title)\nVALUES ($1)\nRETURNING id, title\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "a6a44da6ed04ff2bc84002794353a543d944c0d5cdc49f39608fea0aa90a2f95": {
+    "query": "SELECT id, \n    title\nFROM workspace\nWHERE id = $1\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "ce7601484f2b6cab49b8ef21bec16ebefe59ff10c80e5438884c5268f8c9ab67": {
+    "query": "UPDATE workspace\nSET title = COALESCE($1, title)\nWHERE id = $2\nRETURNING id, title\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "dd2eb967185fb87471eae410bc67c43314f249ee4e195d6a34b91b874bf7f5cf": {
+    "query": "SELECT id,\n    title\nFROM workspace\nORDER BY id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "ddc9d5047645ff601dd794e732f9c49d4ce6526c4212708c285a86f7b78c3dec": {
+    "query": "DELETE FROM workspace\nWHERE id = $1\nRETURNING id, title\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  }
+}


### PR DESCRIPTION
[Ticket](https://airtable.com/tblgtzV3sSwquTkIa/viw8ZHoNqvSvl62lt/recMsd5a69XusQz6p?blocks=hide)

`sqlx` validates that the queries it knows about can be run, either by checking against a real database, or by validating them againsta a json file that lives in root service directory.

We want our Dockerfile to result in a succesful build without needing to check against a real database.

Therefore, a json file representation of the database needs to be created. This can be created through the following command:

`cargo sqlx prepare -- --bin workspace_service`

In CI we will still run the migrations on the test database in the service container and validate against it.


## Pre-review checklist:

- [x] Documentation
