### PR TITLE
Upgrade Linkerd and Argo CD & maintenance docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@
 - [Governance](./governance)
 - [Testing](./testing)
 - [Working with Sealed Secrets](./working-with-sealed-secrets.md)
+- [Maintenance](./maintenance.md)

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,20 @@
+# Maintenance
+
+## Upgrade Linkerd
+
+Our installation scripts always install the latest version of Linkerd. This means our dev clusters are going to stay up-to-date anyway. But since production is a long-lived environment, we need to update Linkerd manually.
+
+Follow the steps with Linkerd CLI in the official upgrade documentation: https://linkerd.io/2/tasks/upgrade/
+
+## Upgrade Argo CD
+
+We load the installation YAML file and commit it to our repository under [`infrastructure/kubernetes/argocd/install/install.yaml`](../infrastructure/kubernetes/argocd/install/install.yaml). To upgrade, update the file to the newest version:
+
+```sh
+curl -L https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml >infrastructure/kubernetes/argocd/install/install.yaml
+yarn prettier --write infrastructure/kubernetes/argocd/install/install.yaml
+```
+
+Then follow the official upgrade documentation: https://argoproj.github.io/argo-cd/operator-manual/upgrading/overview/
+
+**Please note:** We currently use the default Argo CD admin password, which is the argocd-server pod name and generated on first start. After upgrading Argo CD the pod name will change. If you want to change the password to change the new pod name, you can remove the `admin.password` and `admin.passwordMtime` keys in the `argocd-secret` and restart the server pod.

--- a/infrastructure/kubernetes/argocd/install/install.yaml
+++ b/infrastructure/kubernetes/argocd/install/install.yaml
@@ -38,6 +38,18 @@ spec:
         operation:
           description: Operation contains requested operation parameters.
           properties:
+            info:
+              items:
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                required:
+                  - name
+                  - value
+                type: object
+              type: array
             initiatedBy:
               description:
                 OperationInitiator holds information about the operation
@@ -51,6 +63,36 @@ spec:
                 username:
                   description: Name of a user who started operation.
                   type: string
+              type: object
+            retry:
+              description: Retry controls failed sync retry behavior
+              properties:
+                backoff:
+                  description: Backoff is a backoff strategy
+                  properties:
+                    duration:
+                      description:
+                        Duration is the amount to back off. Default unit
+                        is seconds, but could also be a duration (e.g. "2m", "1h")
+                      type: string
+                    factor:
+                      description:
+                        Factor is a factor to multiply the base duration
+                        after each failed retry
+                      format: int64
+                      type: integer
+                    maxDuration:
+                      description:
+                        MaxDuration is the maximum amount of time allowed
+                        for the backoff strategy
+                      type: string
+                  type: object
+                limit:
+                  description:
+                    Limit is the maximum number of attempts when retrying
+                    a container
+                  format: int64
+                  type: integer
               type: object
             sync:
               description: SyncOperation contains sync operation details.
@@ -82,6 +124,8 @@ spec:
                       kind:
                         type: string
                       name:
+                        type: string
+                      namespace:
                         type: string
                     required:
                       - kind
@@ -125,6 +169,11 @@ spec:
                                   - name
                                   - value
                                 type: object
+                              type: array
+                            libs:
+                              description: Additional library search dirs
+                              items:
+                                type: string
                               type: array
                             tlas:
                               description: TLAS is a list of Jsonnet Top-level Arguments
@@ -343,6 +392,11 @@ spec:
                 Destination overrides the kubernetes server and namespace
                 defined in the environment ksonnet app.yaml
               properties:
+                name:
+                  description:
+                    Name of the destination cluster which can be used instead
+                    of server (url) field
+                  type: string
                 namespace:
                   description:
                     Namespace overrides the environment namespace value
@@ -441,6 +495,11 @@ spec:
                               - name
                               - value
                             type: object
+                          type: array
+                        libs:
+                          description: Additional library search dirs
+                          items:
+                            type: string
                           type: array
                         tlas:
                           description: TLAS is a list of Jsonnet Top-level Arguments
@@ -623,8 +682,39 @@ spec:
                       description: "SelfHeal enables auto-syncing if  (default: false)"
                       type: boolean
                   type: object
+                retry:
+                  description: Retry controls failed sync retry behavior
+                  properties:
+                    backoff:
+                      description: Backoff is a backoff strategy
+                      properties:
+                        duration:
+                          description:
+                            Duration is the amount to back off. Default
+                            unit is seconds, but could also be a duration (e.g. "2m",
+                            "1h")
+                          type: string
+                        factor:
+                          description:
+                            Factor is a factor to multiply the base duration
+                            after each failed retry
+                          format: int64
+                          type: integer
+                        maxDuration:
+                          description:
+                            MaxDuration is the maximum amount of time allowed
+                            for the backoff strategy
+                          type: string
+                      type: object
+                    limit:
+                      description:
+                        Limit is the maximum number of attempts when retrying
+                        a container
+                      format: int64
+                      type: integer
+                  type: object
                 syncOptions:
-                  description: Options allow youe to specify whole app sync-options
+                  description: Options allow you to specify whole app sync-options
                   items:
                     type: string
                   type: array
@@ -669,6 +759,7 @@ spec:
                 message:
                   type: string
                 status:
+                  description: Represents resource health status
                   type: string
               type: object
             history:
@@ -680,13 +771,20 @@ spec:
                   RevisionHistory contains information relevant to an application
                   deployment
                 properties:
+                  deployStartedAt:
+                    description: DeployStartedAt holds the time the deployment started
+                    format: date-time
+                    type: string
                   deployedAt:
+                    description: DeployedAt holds the time the deployment completed
                     format: date-time
                     type: string
                   id:
+                    description: ID is an auto incrementing identifier of the RevisionHistory
                     format: int64
                     type: integer
                   revision:
+                    description: Revision holds the revision of the sync
                     type: string
                   source:
                     description:
@@ -721,6 +819,11 @@ spec:
                                     - name
                                     - value
                                   type: object
+                                type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
                                 type: array
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
@@ -905,8 +1008,9 @@ spec:
               type: array
             observedAt:
               description:
-                ObservedAt indicates when the application state was updated
-                without querying latest git state
+                "ObservedAt indicates when the application state was updated
+                without querying latest git state Deprecated: controller no longer
+                updates ObservedAt field"
               format: date-time
               type: string
             operationState:
@@ -926,6 +1030,18 @@ spec:
                 operation:
                   description: Operation is the original requested operation
                   properties:
+                    info:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
                     initiatedBy:
                       description:
                         OperationInitiator holds information about the
@@ -939,6 +1055,37 @@ spec:
                         username:
                           description: Name of a user who started operation.
                           type: string
+                      type: object
+                    retry:
+                      description: Retry controls failed sync retry behavior
+                      properties:
+                        backoff:
+                          description: Backoff is a backoff strategy
+                          properties:
+                            duration:
+                              description:
+                                Duration is the amount to back off. Default
+                                unit is seconds, but could also be a duration (e.g.
+                                "2m", "1h")
+                              type: string
+                            factor:
+                              description:
+                                Factor is a factor to multiply the base
+                                duration after each failed retry
+                              format: int64
+                              type: integer
+                            maxDuration:
+                              description:
+                                MaxDuration is the maximum amount of time
+                                allowed for the backoff strategy
+                              type: string
+                          type: object
+                        limit:
+                          description:
+                            Limit is the maximum number of attempts when
+                            retrying a container
+                          format: int64
+                          type: integer
                       type: object
                     sync:
                       description: SyncOperation contains sync operation details.
@@ -972,6 +1119,8 @@ spec:
                               kind:
                                 type: string
                               name:
+                                type: string
+                              namespace:
                                 type: string
                             required:
                               - kind
@@ -1020,6 +1169,11 @@ spec:
                                           - name
                                           - value
                                         type: object
+                                      type: array
+                                    libs:
+                                      description: Additional library search dirs
+                                      items:
+                                        type: string
                                       type: array
                                     tlas:
                                       description:
@@ -1257,6 +1411,10 @@ spec:
                 phase:
                   description: Phase is the current phase of the operation
                   type: string
+                retryCount:
+                  description: RetryCount contains time of operation retries
+                  format: int64
+                  type: integer
                 startedAt:
                   description: StartedAt contains time of operation start
                   format: date-time
@@ -1352,6 +1510,11 @@ spec:
                                       - name
                                       - value
                                     type: object
+                                  type: array
+                                libs:
+                                  description: Additional library search dirs
+                                  items:
+                                    type: string
                                   type: array
                                 tlas:
                                   description:
@@ -1560,6 +1723,7 @@ spec:
                       message:
                         type: string
                       status:
+                        description: Represents resource health status
                         type: string
                     type: object
                   hook:
@@ -1613,6 +1777,11 @@ spec:
                         ApplicationDestination contains deployment destination
                         information
                       properties:
+                        name:
+                          description:
+                            Name of the destination cluster which can be
+                            used instead of server (url) field
+                          type: string
                         namespace:
                           description:
                             Namespace overrides the environment namespace
@@ -1658,6 +1827,11 @@ spec:
                                       - name
                                       - value
                                     type: object
+                                  type: array
+                                libs:
+                                  description: Additional library search dirs
+                                  items:
+                                    type: string
                                   type: array
                                 tlas:
                                   description:
@@ -1908,6 +2082,25 @@ spec:
         spec:
           description: AppProjectSpec is the specification of an AppProject
           properties:
+            clusterResourceBlacklist:
+              description:
+                ClusterResourceBlacklist contains list of blacklisted cluster
+                level resources
+              items:
+                description:
+                  GroupKind specifies a Group and a Kind, but does not
+                  force a version.  This is useful for identifying concepts during
+                  lookup stages without having partially valid types
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                required:
+                  - group
+                  - kind
+                type: object
+              type: array
             clusterResourceWhitelist:
               description:
                 ClusterResourceWhitelist contains list of whitelisted cluster
@@ -1939,6 +2132,11 @@ spec:
                   ApplicationDestination contains deployment destination
                   information
                 properties:
+                  name:
+                    description:
+                      Name of the destination cluster which can be used
+                      instead of server (url) field
+                    type: string
                   namespace:
                     description:
                       Namespace overrides the environment namespace value
@@ -1994,6 +2192,17 @@ spec:
                 OrphanedResources specifies if controller should monitor
                 orphaned resources of apps in this project
               properties:
+                ignore:
+                  items:
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  type: array
                 warn:
                   description:
                     Warn indicates if warning condition should be created
@@ -2050,6 +2259,22 @@ spec:
                     type: array
                 required:
                   - name
+                type: object
+              type: array
+            signatureKeys:
+              description:
+                List of PGP key IDs that commits to be synced to must be
+                signed with
+              items:
+                description:
+                  SignatureKey is the specification of a key required to
+                  verify commit signatures with
+                properties:
+                  keyID:
+                    description: The ID of the key in hexadecimal notation
+                    type: string
+                required:
+                  - keyID
                 type: object
               type: array
             sourceRepos:
@@ -2393,6 +2618,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
+    app.kubernetes.io/name: argocd-gpg-keys-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-gpg-keys-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-rbac-cm
@@ -2575,7 +2808,7 @@ spec:
             - "20"
             - --operation-processors
             - "10"
-          image: argoproj/argocd:v1.5.7
+          image: argoproj/argocd:v1.7.3
           imagePullPolicy: Always
           livenessProbe:
             httpGet:
@@ -2631,7 +2864,7 @@ spec:
             - -n
             - /usr/local/bin/argocd-util
             - /shared
-          image: argoproj/argocd:v1.5.7
+          image: argoproj/argocd:v1.7.3
           imagePullPolicy: Always
           name: copyutil
           volumeMounts:
@@ -2665,11 +2898,16 @@ spec:
             - ""
             - --appendonly
             - "no"
-          image: redis:5.0.3
+          image: redis:5.0.8
           imagePullPolicy: Always
           name: redis
           ports:
             - containerPort: 6379
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2695,13 +2933,8 @@ spec:
             - argocd-repo-server
             - --redis
             - argocd-redis:6379
-          image: argoproj/argocd:v1.5.7
+          image: argoproj/argocd:v1.7.3
           imagePullPolicy: Always
-          livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            tcpSocket:
-              port: 8081
           name: argocd-repo-server
           ports:
             - containerPort: 8081
@@ -2716,6 +2949,10 @@ spec:
               name: ssh-known-hosts
             - mountPath: /app/config/tls
               name: tls-certs
+            - mountPath: /app/config/gpg/source
+              name: gpg-keys
+            - mountPath: /app/config/gpg/keys
+              name: gpg-keyring
       volumes:
         - configMap:
             name: argocd-ssh-known-hosts-cm
@@ -2723,6 +2960,11 @@ spec:
         - configMap:
             name: argocd-tls-certs-cm
           name: tls-certs
+        - configMap:
+            name: argocd-gpg-keys-cm
+          name: gpg-keys
+        - emptyDir: {}
+          name: gpg-keyring
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2746,14 +2988,8 @@ spec:
             - argocd-server
             - --staticassets
             - /shared/app
-          image: argoproj/argocd:v1.5.7
+          image: argoproj/argocd:v1.7.3
           imagePullPolicy: Always
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 3
-            periodSeconds: 30
           name: argocd-server
           ports:
             - containerPort: 8080


### PR DESCRIPTION
I upgraded Linkerd in production to the 2.8.1 (it was 2.7.1). This prompted me to also:

- Document the process
- Upgrade Argo CD and also document this process

### Review Notes

`infrastructure/kubernetes/argocd/install/install.yaml` is autogenerated from the latest Argo CD. See documentation for how it was generated.