### PR TITLE
Page focus accessibility

### DIFF
--- a/frontend/components/Login/LoginPanel.tsx
+++ b/frontend/components/Login/LoginPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Panel } from "nhsuk-react-components";
 import styled from "styled-components";
+import { MainHeading } from "../../components/MainHeading";
 
 type LoginPanelProps = {
   label: string;
@@ -29,7 +30,7 @@ const StyledLoginPanel = styled(Panel)`
 const LoginPanel = ({ label, text }: LoginPanelProps) => {
   return (
     <StyledLoginPanel>
-      <h1>{label}</h1>
+      <MainHeading>{label}</MainHeading>
       <h2>{text}</h2>
     </StyledLoginPanel>
   );

--- a/frontend/components/MainHeading/MainHeading.tsx
+++ b/frontend/components/MainHeading/MainHeading.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+interface Props {
+  children: string;
+}
+
+/**
+ * This component should be used on every page as the main heading.
+ * It's a workaround for a known next.js accessibility issue that doesn't read out
+ * headlines on navigation
+ */
+const MainHeading = ({ children }: Props) => {
+  return <h1 aria-live="polite">{children}</h1>;
+};
+
+export default MainHeading;

--- a/frontend/components/MainHeading/index.tsx
+++ b/frontend/components/MainHeading/index.tsx
@@ -1,0 +1,3 @@
+import MainHeading from "./MainHeading";
+
+export { MainHeading };

--- a/frontend/pages/admin/workspaces.tsx
+++ b/frontend/pages/admin/workspaces.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components";
 import { Input, Form, Button } from "nhsuk-react-components";
 import { GetServerSideProps } from "next";
 import { requireAuthentication } from "../../lib/auth";
+import { MainHeading } from "../../components/MainHeading";
 
 export const getServerSideProps: GetServerSideProps = requireAuthentication(
   async () => {
@@ -48,7 +49,7 @@ const H2 = styled.h2`
   border-top: 1px solid ${theme.colorNhsukGrey1};
   padding-top: 24px;
   margin-bottom: 8px;
-  color: ${theme.colorNhsukGrey1} 
+  color: ${theme.colorNhsukGrey1}
   `}
 `;
 
@@ -95,7 +96,7 @@ const CreateWorkspace = () => {
       <PageLayout>
         <Header />
         <PageContent>
-          <h1>Create a workspace</h1>
+          <MainHeading>Create a workspace</MainHeading>
           <H2>Workspace details</H2>
           <p> Fields marked with * are required.</p>
 

--- a/frontend/pages/workspaces/pharmacy.tsx
+++ b/frontend/pages/workspaces/pharmacy.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { GetServerSideProps } from "next";
 import { requireAuthentication } from "../../lib/auth";
+import { Header } from "../../components/Header";
+import Link from "next/link";
+import { MainHeading } from "../../components/MainHeading";
 
 export const getServerSideProps: GetServerSideProps = requireAuthentication(
   async () => {
@@ -13,8 +16,12 @@ export const getServerSideProps: GetServerSideProps = requireAuthentication(
 const PrivatePage = () => {
   return (
     <>
-      <div>Private Pharmacy Page</div>
-      <div>This is a different private page</div>
+      <Header />
+      <MainHeading>Pharmacy Page</MainHeading>
+      <p>This is a different private page</p>
+      <Link href="/workspaces/private">
+        <a>Private workspace</a>
+      </Link>
     </>
   );
 };

--- a/frontend/pages/workspaces/private.tsx
+++ b/frontend/pages/workspaces/private.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { GetServerSideProps } from "next";
 import { requireAuthentication, User } from "../../lib/auth";
+import { MainHeading } from "../../components/MainHeading";
 
 interface Props {
   user: User;
@@ -17,7 +18,7 @@ export const getServerSideProps: GetServerSideProps<Props> = requireAuthenticati
 const PrivatePage = (props: Props) => {
   return (
     <>
-      <div>Private Page</div>
+      <MainHeading>Private Page</MainHeading>
       <div>User ID: {props.user.id}</div>
       <div>Name: {props.user.name}</div>
       <div>Emails: {props.user.emails.join(", ")}</div>


### PR DESCRIPTION
[Ticket]()

[Zeplin]()

## Acceptance Criteria

- Added aria-live label to ensure focus to H1 upon navigating to new page
- Made a MainHeading component which should be used for all h1 headings in page

## Pre-review checklist:

- [ ] Tests

- [ ] Documentation

- [ ] Analytics (user analytics, e.g. Google Analytics)

- [ ] Observability (metrics/tracing)

- [ ] Feature flag

- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
