### PR TITLE
Dynamic assetprefix and instrumentationkey for frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,9 @@ COPY . .
 
 # Building app
 RUN yarn test
-RUN NEXT_PUBLIC_INSTRUMENTATION_KEY=18be3b83-4ad5-4186-a7b6-f65dd1253a77 yarn build
+RUN NEXT_PUBLIC_INSTRUMENTATION_KEY=__FNHS_INSTRUMENTATION_KEY__ yarn build
 
 # Running the app
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD [ "yarn", "start" ]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 # Building app
 RUN yarn test
-RUN NEXT_PUBLIC_INSTRUMENTATION_KEY=__FNHS_INSTRUMENTATION_KEY__ yarn build
+RUN ORIGIN=__FNHS_ORIGIN__ NEXT_PUBLIC_INSTRUMENTATION_KEY=__FNHS_INSTRUMENTATION_KEY__ yarn build
 
 # Running the app
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# Replace placeholders
+find .next -type f -not -path '.next/cache/*' -exec sed -i \
+	-e "s#__FNHS_ASSET_PREFIX__#$ORIGIN#g" \
+	-e "s#__FNHS_INSTRUMENTATION_KEY__#$NEXT_PUBLIC_INSTRUMENTATION_KEY#g" \
+	{} +
+
+# Start application
+exec "$@"

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -eu
 
 # Replace placeholders
 find .next -type f -not -path '.next/cache/*' -exec sed -i \
-	-e "s#__FNHS_ASSET_PREFIX__#$ORIGIN#g" \
+	-e "s#__FNHS_ORIGIN__#$ORIGIN#g" \
 	-e "s#__FNHS_INSTRUMENTATION_KEY__#$NEXT_PUBLIC_INSTRUMENTATION_KEY#g" \
 	{} +
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,6 @@
 const withImages = require("next-images");
-const isProd = process.env.NODE_ENV === "production";
 
 module.exports = withImages({
   inlineImageLimit: 0,
-  assetPrefix: isProd ? "__FNHS_ASSET_PREFIX__" : "",
+  assetPrefix: process.env.ORIGIN,
 });

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,5 +3,5 @@ const isProd = process.env.NODE_ENV === "production";
 
 module.exports = withImages({
   inlineImageLimit: 0,
-  assetPrefix: isProd ? "https://beta.future.nhs.uk" : "",
+  assetPrefix: isProd ? "__FNHS_ASSET_PREFIX__" : "",
 });


### PR DESCRIPTION
## Description

We currently have a problem with our frontend deployment on dev clusters:

- In order to serve a login page template for AAD from our Next.js app, we had to make our asset URLs absolute. We did that using an assetPrefix, which is only set for production builds. Because that's inserted to pages at build time we set it to beta.future.nhs.uk.
- We also deploy production builds to our dev clusters. Those run under a different domain, though.
- This means that assets currently don't load on dev clusters, unless the same asset also exists in production already.

This fixes the problem by:

- Using a placeholder name during build time (`__FNHS_ORIGIN__`)
- Replacing the placeholder with the actual domain on Docker container startup.

Since that adds some form of templating, it also enables us to do the same for the Application Insights instrumentation key. So we do that as well.

### Downside:

This makes it impossible to have a read-only file system in the Docker container. We can probably fix that by doing the placeholder replacement in express.js. But then we take on a runtime cost. We could then shift the load to a CDN, which can cache all the resources. But that's more complex, so let's think about this later.

## Testing information

- Test the site loads on dev clusters and URLs for assets are absolute and use the domain of that dev cluster.
- Also test that it uses the correct instrumentation key.

## Test:

- [x] Tested locally

- [x] Tested on dev cluster