### PR TITLE
Enforce order of imports.

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -21,9 +21,28 @@
     "ecmaVersion": 11,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint"],
+  "plugins": ["react", "@typescript-eslint", "import"],
   "rules": {
     "no-unused-vars": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal"],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ],
     "@typescript-eslint/no-unused-vars": ["error"]
   },
   "settings": {

--- a/frontend/components/Head/Head.tsx
+++ b/frontend/components/Head/Head.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { default as NextHead } from "next/head";
 
 interface Props {

--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import styled from "styled-components";
 
 const StyledHeader = styled.header`

--- a/frontend/components/Login/Gradient.tsx
+++ b/frontend/components/Login/Gradient.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import styled from "styled-components";
 
 type GradientProps = {

--- a/frontend/components/Login/Login.tsx
+++ b/frontend/components/Login/Login.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import styled from "styled-components";
 
 const StyledDiv = styled.div`

--- a/frontend/components/Login/LoginPanel.tsx
+++ b/frontend/components/Login/LoginPanel.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+
 import { Panel } from "nhsuk-react-components";
 import styled from "styled-components";
+
 import { MainHeading } from "../../components/MainHeading";
 
 type LoginPanelProps = {

--- a/frontend/components/Login/index.tsx
+++ b/frontend/components/Login/index.tsx
@@ -1,5 +1,5 @@
+import Gradient from "./Gradient";
 import Login from "./Login";
 import LoginPanel from "./LoginPanel";
-import Gradient from "./Gradient";
 
 export { Login, LoginPanel, Gradient };

--- a/frontend/components/Textarea/Textarea.tsx
+++ b/frontend/components/Textarea/Textarea.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLProps } from "react";
+
 import classNames from "classnames";
 import FormGroup from "nhsuk-react-components/lib/util/FormGroup";
 import { FormElementProps } from "nhsuk-react-components/lib/util/types/FormTypes";

--- a/frontend/components/next-applicationinsights.ts
+++ b/frontend/components/next-applicationinsights.ts
@@ -1,12 +1,12 @@
 // This file is taken from https://github.com/goenning/next-applicationinsights and edited to remove the 'getInitialProps' method in order to allow for static generation.
 import * as React from "react";
-import { AppProps, default as NextApp } from "next/app";
 
 import {
   ApplicationInsights,
   IConfiguration,
   IConfig,
 } from "@microsoft/applicationinsights-web";
+import { AppProps, default as NextApp } from "next/app";
 
 const IS_BROWSER = typeof window !== "undefined";
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -3,6 +3,7 @@ import {
   GetServerSidePropsContext,
   GetServerSidePropsResult,
 } from "next";
+
 import { redirect } from "./redirect";
 
 export interface User {

--- a/frontend/lib/events.test.ts
+++ b/frontend/lib/events.test.ts
@@ -1,7 +1,8 @@
-import { sendEvent } from "./events";
 import EventGridClient from "azure-eventgrid";
-import { withEnvVars } from "./test-helpers/environment";
+
+import { sendEvent } from "./events";
 import { withMockedConsole } from "./test-helpers/console";
+import { withEnvVars } from "./test-helpers/environment";
 
 jest.mock("azure-eventgrid");
 

--- a/frontend/lib/events.ts
+++ b/frontend/lib/events.ts
@@ -1,6 +1,6 @@
-import { v4 as uuid } from "uuid";
 import EventGridClient from "azure-eventgrid";
 import { TopicCredentials } from "ms-rest-azure";
+import { v4 as uuid } from "uuid";
 
 // TODO: Generate strongly typed models for the different event types and data versions
 export interface Event {

--- a/frontend/lib/redirect.ts
+++ b/frontend/lib/redirect.ts
@@ -1,4 +1,5 @@
 import { ParsedUrlQuery } from "querystring";
+
 import { GetServerSidePropsContext } from "next";
 
 /// Inspired by the api of the `next-redirect` package, but I couldn't find any typings

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "babel-jest": "^26.3.0",
     "babel-plugin-styled-components": "^1.11.1",
     "eslint": "^7.8.1",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-react": "^7.20.6",
     "http-proxy-middleware": "^1.0.5",
     "husky": "^4.2.5",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,8 +1,11 @@
 import React from "react";
+
 import App from "next/app";
-import { withApplicationInsights } from "../components/next-applicationinsights";
-import "./_app.scss";
 import { ThemeProvider } from "styled-components";
+
+import { withApplicationInsights } from "../components/next-applicationinsights";
+
+import "./_app.scss";
 
 // Extract our Sass variables into a JS object
 const theme = require('sass-extract-loader?{"includePaths":["."],"plugins": ["sass-extract-js"]}!../node_modules/nhsuk-frontend/packages/core/all.scss');

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Document from "next/document";
 import { ServerStyleSheet } from "styled-components";
 

--- a/frontend/pages/admin/workspaces.tsx
+++ b/frontend/pages/admin/workspaces.tsx
@@ -1,16 +1,18 @@
 import React, { useState } from "react";
-import { useForm } from "react-hook-form";
+
 import { GraphQLClient } from "graphql-request";
-import { getSdk } from "../../lib/generated/graphql";
+import { GetServerSideProps } from "next";
+import { Input, Form, Button } from "nhsuk-react-components";
+import { useForm } from "react-hook-form";
+import styled from "styled-components";
+
 import { Head } from "../../components/Head";
 import { Header } from "../../components/Header";
+import { MainHeading } from "../../components/MainHeading";
 import { PageLayout } from "../../components/PageLayout";
 import { Textarea } from "../../components/Textarea";
-import styled from "styled-components";
-import { Input, Form, Button } from "nhsuk-react-components";
-import { GetServerSideProps } from "next";
 import { requireAuthentication } from "../../lib/auth";
-import { MainHeading } from "../../components/MainHeading";
+import { getSdk } from "../../lib/generated/graphql";
 
 export const getServerSideProps: GetServerSideProps = requireAuthentication(
   async () => {

--- a/frontend/pages/api/graphql.ts
+++ b/frontend/pages/api/graphql.ts
@@ -1,6 +1,7 @@
-import { ApolloServer } from "apollo-server-micro";
 import { ApolloGateway } from "@apollo/gateway";
+import { ApolloServer } from "apollo-server-micro";
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { User } from "../../lib/auth";
 
 const gateway = new ApolloGateway({

--- a/frontend/pages/auth-page-layouts/login.tsx
+++ b/frontend/pages/auth-page-layouts/login.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { PageLayout } from "../../components/PageLayout";
+
+import { GetServerSideProps } from "next";
+import styled from "styled-components";
+
 import { Header } from "../../components/Header";
 import { Login } from "../../components/Login";
-import { GetServerSideProps } from "next";
 import { Gradient } from "../../components/Login";
 import { LoginPanel } from "../../components/Login";
-import styled from "styled-components";
+import { PageLayout } from "../../components/PageLayout";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader(

--- a/frontend/pages/dev.tsx
+++ b/frontend/pages/dev.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
 import Head from "next/head";
-import Layout from "../components/layout";
 import Link from "next/link";
+
+import Layout from "../components/layout";
 
 const Dev = () => {
   // this is purely here to check that we receive client side exceptions within Application Insights

--- a/frontend/pages/greetings/[name].tsx
+++ b/frontend/pages/greetings/[name].tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
-import Link from "next/link";
-import axios from "axios";
 
+import axios from "axios";
 import { GetServerSideProps } from "next";
+import Link from "next/link";
+
 import { getGreeting } from "../../lib/greetings";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+
 import Head from "next/head";
+
 import Layout from "../components/layout";
 import hypeStyles from "../styles/hype.module.css";
 

--- a/frontend/pages/workspaces/pharmacy.tsx
+++ b/frontend/pages/workspaces/pharmacy.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+
 import { GetServerSideProps } from "next";
-import { requireAuthentication } from "../../lib/auth";
-import { Header } from "../../components/Header";
 import Link from "next/link";
+
+import { Header } from "../../components/Header";
 import { MainHeading } from "../../components/MainHeading";
+import { requireAuthentication } from "../../lib/auth";
 
 export const getServerSideProps: GetServerSideProps = requireAuthentication(
   async () => {

--- a/frontend/pages/workspaces/private.tsx
+++ b/frontend/pages/workspaces/private.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
 import { GetServerSideProps } from "next";
-import { requireAuthentication, User } from "../../lib/auth";
+
 import { MainHeading } from "../../components/MainHeading";
+import { requireAuthentication, User } from "../../lib/auth";
 
 interface Props {
   user: User;

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,13 +1,14 @@
-const express = require("express");
-const pg = require("pg");
-const session = require("express-session");
+const { promises: fs } = require("fs");
+const url = require("url");
+
 const pgSession = require("connect-pg-simple")(session);
+const dotenv = require("dotenv");
+const express = require("express");
+const session = require("express-session");
+const next = require("next");
 const passport = require("passport");
 const OIDCStrategy = require("passport-azure-ad").OIDCStrategy;
-const next = require("next");
-const dotenv = require("dotenv");
-const url = require("url");
-const { promises: fs } = require("fs");
+const pg = require("pg");
 
 const devProxy = {
   "/hello": {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,14 +1,15 @@
-const { promises: fs } = require("fs");
-const url = require("url");
-
-const pgSession = require("connect-pg-simple")(session);
-const dotenv = require("dotenv");
+/* eslint-disable import/order */
 const express = require("express");
 const session = require("express-session");
-const next = require("next");
+const pg = require("pg");
+const pgSession = require("connect-pg-simple")(session);
 const passport = require("passport");
 const OIDCStrategy = require("passport-azure-ad").OIDCStrategy;
-const pg = require("pg");
+const next = require("next");
+const dotenv = require("dotenv");
+
+const url = require("url");
+const { promises: fs } = require("fs");
 
 const devProxy = {
   "/hello": {

--- a/frontend/tracing.js
+++ b/frontend/tracing.js
@@ -1,13 +1,13 @@
 "use strict";
 
+const {
+  AzureMonitorTraceExporter,
+} = require("@azure/monitor-opentelemetry-exporter");
 const { NodeTracerProvider } = require("@opentelemetry/node");
 const {
   BatchSpanProcessor,
   ConsoleSpanExporter,
 } = require("@opentelemetry/tracing");
-const {
-  AzureMonitorTraceExporter,
-} = require("@azure/monitor-opentelemetry-exporter");
 
 const provider = new NodeTracerProvider({
   plugins: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2364,6 +2364,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
   integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/jsonwebtoken@^8.5.0":
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
@@ -3255,6 +3260,14 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flat@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
+  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 array.prototype.flatmap@^1.2.3:
   version "1.2.3"
@@ -4369,6 +4382,11 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
@@ -4727,7 +4745,7 @@ debounce@^1.2.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4890,6 +4908,14 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -5205,6 +5231,41 @@ escodegen@^1.14.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-import-resolver-node@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.13.1"
+
+eslint-module-utils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
+  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
+  dependencies:
+    debug "^2.6.9"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-import@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
+  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flat "^1.2.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.3"
+    eslint-module-utils "^2.6.0"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.1"
+    read-pkg-up "^2.0.0"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
 
 eslint-plugin-react@^7.20.6:
   version "7.20.6"
@@ -5710,6 +5771,13 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -7723,6 +7791,16 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -7754,6 +7832,14 @@ loader-utils@^1.1.0, loader-utils@^1.2.3:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -8895,12 +8981,26 @@ p-limit@3.0.2:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -8934,6 +9034,11 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -9157,6 +9262,13 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+  dependencies:
+    pify "^2.0.0"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -9268,6 +9380,13 @@ pirates@^4.0.1:
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
 
 pkg-dir@^3.0.0:
   version "3.0.0"
@@ -9678,6 +9797,14 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -9695,6 +9822,15 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read-pkg@^5.2.0:
   version "5.2.0"
@@ -9997,7 +10133,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -10926,6 +11062,11 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
@@ -11297,6 +11438,16 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"


### PR DESCRIPTION
![](https://media.giphy.com/media/tJMVcTfzDdL1pOGxlk/giphy.gif)

This PR is to create some logical order with our imports - the rules can be found in .eslintrc.json and seem reasonably sane from a react point of view - lifted from what i found other people out there are using.

NOTE: Server.js has a weird order of imports (from eslint perspective), and there doesn't seem massive value in adding extra rules just for that file, so i have ignored it.

What do people think?