### PR TITLE
Add curl to workspace-service release image

### DIFF
--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -28,9 +28,9 @@ FROM debian:buster-slim AS release-context
 
 RUN apt-get update && apt-get install -y \
     tini \
+    libssl1.1 \
+    curl \
     ;
-
-RUN apt install libssl1.1 -y
 
 RUN useradd svc
 

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -29,7 +29,7 @@ FROM debian:buster-slim AS release-context
 RUN apt-get update && apt-get install -y \
     tini \
     libssl1.1 \
-    curl \
+    libcurl4 \
     ;
 
 RUN useradd svc


### PR DESCRIPTION
With the event client we now need `libcurl` in the workspace service image.

More context. The event client relies on the `surf` crate, which uses `isahc`, which uses [`curl`](https://crates.io/crates/curl). By default this uses a shared system library. It can also be configured to use a statically linked libcurl, but I think installing it via apt is okay. 🙂 

Tested on my dev cluster.