### PR TITLE
Speed up Rust builds: build outside Docker and caching cargo dirs

### DIFF
--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -34,7 +34,6 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - uses: actions-rs/toolchain@v1
-        working-directory: futurenhs-platform
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          override: true
           components: clippy
       - name: Cache sqlx
         id: cache-sqlx

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -37,26 +37,41 @@ jobs:
         with:
           toolchain: stable
       - name: Cache sqlx
+        id: cache-sqlx
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/bin/sqlx
             ~/.cargo/bin/cargo-sqlx
-          key: 0.1.0-beta.1
-      - name: Run DB migrations on test database
+          key: sqlx-0.1.0-beta.1
+      - name: Install sqlx
+        if: steps.cache-sqlx.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/frigus02/sqlx --rev 106a6a83952bfc0e3316d54f99d865e469dcc15a sqlx-cli
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}
+      - name: Build
         working-directory: futurenhs-platform/workspace-service
         run: |
           set -e
-          command -v cargo-sqlx || cargo install --git https://github.com/frigus02/sqlx --rev 106a6a83952bfc0e3316d54f99d865e469dcc15a sqlx-cli
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
           cargo sqlx prepare --check -- --bin workspace_service
-      - name: "Build & Push image"
+          export SQLX_OFFLINE=true
+          cargo clippy --release -- -D warnings
+          cargo build --release
+          export TEST_DATABASE_URL=$DATABASE_URL
+          cargo test --release
+      - name: Build & Push image
         working-directory: futurenhs-platform/workspace-service
         run: |
           TAG="$(git rev-parse --short=7 ${{ github.sha }})"
           make docker-build tag=${TAG}
-          make docker-test TEST_DATABASE_URL=postgres://postgres:postgres@postgres:5432
           make docker-push tag=${TAG}
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ secrets.REGISTRY_LOGIN_SERVER }}/workspace-service:${TAG})"
           echo ::set-env name=TAG::$TAG

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -33,6 +33,8 @@ jobs:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Make toolchain version available in current directory
+        run: cp futurenhs-platform/rust-toolchain .
       - uses: actions-rs/toolchain@v1
       - name: Cache sqlx
         id: cache-sqlx

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,6 +36,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Install clippy
+        working-directory: futurenhs-platform
+        run: rustup component add clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2
@@ -63,7 +66,7 @@ jobs:
           sqlx migrate run
           cargo sqlx prepare --check -- --release --bin workspace_service
           export SQLX_OFFLINE=true
-          #cargo clippy --release -- -D warnings
+          cargo clippy --release -- -D warnings
           cargo build --release
           export TEST_DATABASE_URL=$DATABASE_URL
           cargo test --release

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,6 +36,7 @@ jobs:
       - name: Make toolchain version available in current directory
         run: cp futurenhs-platform/rust-toolchain .
       - uses: actions-rs/toolchain@v1
+        components: clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,7 +36,8 @@ jobs:
       - name: Make toolchain version available in current directory
         run: cp futurenhs-platform/rust-toolchain .
       - uses: actions-rs/toolchain@v1
-        components: clippy
+        with:
+          components: clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          override: true
+          default: true
           components: clippy
       - name: Cache sqlx
         id: cache-sqlx

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -36,8 +36,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          default: true
-          components: clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2
@@ -63,13 +61,13 @@ jobs:
           set -e
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
-          cargo sqlx prepare --check -- --bin workspace_service
+          cargo sqlx prepare --check -- --release --bin workspace_service
           export SQLX_OFFLINE=true
-          cargo clippy --release -- -D warnings
+          #cargo clippy --release -- -D warnings
           cargo build --release
           export TEST_DATABASE_URL=$DATABASE_URL
           cargo test --release
-      - name: Build & Push image
+      - name: Build & push image
         working-directory: futurenhs-platform/workspace-service
         run: |
           TAG="$(git rev-parse --short=7 ${{ github.sha }})"
@@ -97,7 +95,7 @@ jobs:
           else
             git checkout HEAD -b pr-$GITHUB_HEAD_REF
           fi
-      - name: Update image tag and test dev overlay creation
+      - name: Update image tag and create dev overlays
         run: |
           cd $HOME
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -34,11 +34,7 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: Install clippy
         working-directory: futurenhs-platform
-        run: rustup component add clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -56,7 +56,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            futurenhs-platform/workspace-service/target
           key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}
       - name: Build
         working-directory: futurenhs-platform/workspace-service

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -34,6 +34,8 @@ jobs:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Make toolchain version available in current directory
+        run: cp futurenhs-platform/rust-toolchain .
       - uses: actions-rs/toolchain@v1
       - name: Cache sqlx
         id: cache-sqlx

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Make toolchain version available in current directory
         run: cp futurenhs-platform/rust-toolchain .
       - uses: actions-rs/toolchain@v1
+        components: clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -37,7 +37,8 @@ jobs:
       - name: Make toolchain version available in current directory
         run: cp futurenhs-platform/rust-toolchain .
       - uses: actions-rs/toolchain@v1
-        components: clippy
+        with:
+          components: clippy
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -35,41 +35,53 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        working-directory: futurenhs-platform
       - name: Cache sqlx
+        id: cache-sqlx
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/bin/sqlx
             ~/.cargo/bin/cargo-sqlx
-          key: 0.1.0-beta.1
-      - name: Run DB migrations on test database
+          key: sqlx-0.1.0-beta.1
+      - name: Install sqlx
+        if: steps.cache-sqlx.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/frigus02/sqlx --rev 106a6a83952bfc0e3316d54f99d865e469dcc15a sqlx-cli
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            futurenhs-platform/workspace-service/target
+          key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}
+      - name: Build
         working-directory: futurenhs-platform/workspace-service
         run: |
           set -e
-          command -v cargo-sqlx || cargo install --git https://github.com/frigus02/sqlx --rev 106a6a83952bfc0e3316d54f99d865e469dcc15a sqlx-cli
           export DATABASE_URL=postgres://postgres:postgres@localhost:5432
           sqlx migrate run
-          cargo sqlx prepare --check -- --bin workspace_service
-      - name: "Build & Push image"
+          cargo sqlx prepare --check -- --release --bin workspace_service
+          export SQLX_OFFLINE=true
+          cargo clippy --release -- -D warnings
+          cargo build --release
+          export TEST_DATABASE_URL=$DATABASE_URL
+          cargo test --release
+      - name: Build & push image
+        working-directory: futurenhs-platform/workspace-service
         run: |
-          cd $GITHUB_WORKSPACE/futurenhs-platform/workspace-service
           TAG="$(git rev-parse --short=7 ${{ github.sha }})"
           make docker-build tag=${TAG}
-          make docker-test TEST_DATABASE_URL=postgres://postgres:postgres@postgres:5432
           make docker-push tag=${TAG}
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ secrets.REGISTRY_LOGIN_SERVER }}/workspace-service:${TAG})"
           echo ::set-env name=TAG::$TAG
           echo ::set-env name=DIGEST::$DIGEST
-
       - name: Clone Deployments repo
         uses: actions/checkout@v2
         with:
           repository: FutureNHS/futurenhs-deployments
           path: futurenhs-deployments
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-
       - name: Copy manifests
         run: |
           set -eux

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -35,7 +35,6 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - uses: actions-rs/toolchain@v1
-        working-directory: futurenhs-platform
       - name: Cache sqlx
         id: cache-sqlx
         uses: actions/cache@v2

--- a/workspace-service/.dockerignore
+++ b/workspace-service/.dockerignore
@@ -1,0 +1,2 @@
+**/*
+!target/release/workspace_service

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -10,6 +10,11 @@ RUN useradd svc
 
 COPY target/release/workspace_service /
 
+# Test if the binary is executable in this environment. This ensures it's built
+# for the correct architecture and all shared libraries are available.
+# SELFCHECK_ONLY=1 means the binary will immediately exit.
+RUN SELFCHECK_ONLY=1 /workspace_service
+
 RUN chown -R svc /workspace_service
 
 USER svc

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -3,7 +3,6 @@ FROM debian:buster-slim
 RUN apt-get update && apt-get install -y \
     tini \
     libssl1.1 \
-    libcurl4 \
     ;
 
 RUN useradd svc

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:buster-slim
 RUN apt-get update && apt-get install -y \
     tini \
     libssl1.1 \
+    libcurl4 \
     ;
 
 RUN useradd svc

--- a/workspace-service/Dockerfile
+++ b/workspace-service/Dockerfile
@@ -1,30 +1,4 @@
-# Setup rust build environment
-FROM rust:1.46.0 AS build-context
-
-RUN rustup component add rustfmt clippy
-
-WORKDIR /usr/src/
-COPY event-models ./event-models
-WORKDIR /usr/src/workspace-service
-
-COPY workspace-service/Cargo.toml .
-COPY workspace-service/Cargo.lock .
-
-ENV SQLX_OFFLINE=true
-
-# Layer hack: Build an empty program to compile dependencies and place on their own layer.
-# This cuts down build time
-
-# it was borrowed from here:
-# https://github.com/deislabs/krustlet/blob/master/Dockerfile#L7
-RUN mkdir -p ./src/ && echo 'fn main() {}' >./src/main.rs && echo '' >./src/lib.rs
-
-RUN cargo fetch
-
-RUN cargo build --release --locked && rm -rf ./target/release/.fingerprint/workspace_service-*
-
-# Setup debian release environment
-FROM debian:buster-slim AS release-context
+FROM debian:buster-slim
 
 RUN apt-get update && apt-get install -y \
     tini \
@@ -34,28 +8,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd svc
 
-# Build real binaries now, as late as possible
-FROM build-context AS build
-
-COPY workspace-service/src ./src
-COPY workspace-service/sql ./sql
-COPY workspace-service/sqlx-data.json .
-COPY workspace-service/migrations ./migrations
-
-RUN cargo clippy --release -- -D warnings && cargo build --release
-
-# This target is skipped in the normal `docker build` flow because it requires the database
-# Use `docker build --target test` to run it
-FROM build AS test
-ARG TEST_DATABASE_URL=postgres://postgres:postgres@172.17.0.1:5432
-ENV TEST_DATABASE_URL=$TEST_DATABASE_URL
-
-RUN cargo test --release
-
-# Create the release
-FROM release-context AS release
-
-COPY --from=build /usr/src/workspace-service/target/release/workspace_service /
+COPY target/release/workspace_service /
 
 RUN chown -R svc /workspace_service
 

--- a/workspace-service/Makefile
+++ b/workspace-service/Makefile
@@ -12,30 +12,11 @@ test: ## Run tests [TEST=test_name (optional)]
 
 .PHONY: docker-build
 docker-build: ## Build and tag Docker image
-	tar cv \
-		--exclude event-models/typescript \
-		--exclude manifests \
-		--exclude target \
-		Dockerfile \
-		-C .. event-models workspace-service | \
-		DOCKER_BUILDKIT=1 docker build - \
-			--progress plain \
-			--tag $(app) \
-			--tag $(image) \
-			--tag $(image):$(tag)
-
-.PHONY: docker-test
-docker-test: ## Run tests in Docker
-	tar cv \
-		--exclude event-models/typescript \
-		--exclude manifests \
-		--exclude target \
-		Dockerfile \
-		-C .. event-models workspace-service | \
-		DOCKER_BUILDKIT=1 docker build - \
-			--progress plain \
-			--target test \
-			--build-arg TEST_DATABASE_URL=$$TEST_DATABASE_URL
+	DOCKER_BUILDKIT=1 docker build . \
+		--progress plain \
+		--tag $(app) \
+		--tag $(image) \
+		--tag $(image):$(tag)
 
 .PHONY: docker-run
 docker-run: ## Run Docker image

--- a/workspace-service/src/main.rs
+++ b/workspace-service/src/main.rs
@@ -12,6 +12,11 @@ use url::Url;
 async fn main() -> Result<()> {
     dotenv().ok();
 
+    if env::var_os("SELFCHECK_ONLY").is_some() {
+        println!("SELFCHECK_ONLY is set. Exiting...");
+        return Ok(());
+    }
+
     let provider = if let Ok(instrumentation_key) = env::var("INSTRUMENTATION_KEY") {
         let exporter = opentelemetry_application_insights::Exporter::new(instrumentation_key);
         let batch_exporter = BatchSpanProcessor::builder(


### PR DESCRIPTION
I tested ways of speeding up Rust builds:

- build outside Docker and caching cargo dirs (this one)
- Docker layer caching #232

Caching Docker layers is nice, because it means you can replicate the same Docker build locally. But caching is slow. It takes 7mins to restore and 7mins to store the cache (16mins total build time when everything is cached).

Building outside Docker and caching the cargo directories is much faster (3mins total build time when everything is cached). Downside: you cannot create a Docker image locally anymore. Because we build on Mac the binary doesn’t run on Linux. But in CI it's okay because the build runs on Ubuntu.

I think I'm in favor if this one here. I think it's super rare that we need to replicate local Docker builds and this one makes the build much quicker.