### PR TITLE
Add line to script to switch context.

### DIFF
--- a/infrastructure/scripts/install-everything.sh
+++ b/infrastructure/scripts/install-everything.sh
@@ -39,6 +39,7 @@ OVERWRITE=localfiles $REPO_ROOT/infrastructure/scripts/create-dev-environment.sh
 )
 
 az aks get-credentials --overwrite-existing --resource-group platform-dev-$FNHSNAME --name dev-$FNHSNAME
+CURRENT_CONTEXT=$(kubectl config current-context)
 
 if [ "$ENVIRONMENT" != "$CURRENT_CONTEXT" ]; then
 	echo "You want to deploy to:   $ENVIRONMENT"


### PR DESCRIPTION
User may've been using a different cluster before running script, so makes sure the context is correct before the subsequent azure commands are run. 