### PR TITLE
Terraform update to 0.13.3

### DIFF
--- a/.github/workflows/infrastructure-branch.yaml
+++ b/.github/workflows/infrastructure-branch.yaml
@@ -18,7 +18,7 @@ jobs:
           path: futurenhs-platform
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.0
+          terraform_version: 0.13.3
       - name: Validate Terraform of dev environment
         working-directory: futurenhs-platform/infrastructure/environments/dev
         run: |

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.0
+          terraform_version: 0.13.3
       - name: Run Terraform fmt
         run: |
           cd infrastructure

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ target/
 dev-*/
 !dev-template/
 terraform.tfvars
+backend-config.tfvars
 node_modules
 .vscode/

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -18,12 +18,12 @@ We use [Terraform](https://www.terraform.io/) to build our environments.
    brew install chtf
    ```
 
-1. Select version 0.13.0:
+1. Select version 0.13.3:
 
    ```bash
-   tfswitch 0.13.0
+   tfswitch 0.13.3
    # or
-   chtf 0.13.0
+   chtf 0.13.3
    ```
 
 1. Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) and login to Azure:

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.0"
+  required_version = "0.13.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/infrastructure/environments/production/main.tf
+++ b/infrastructure/environments/production/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.0"
+  required_version = "0.13.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/infrastructure/environments/shared-dev/main.tf
+++ b/infrastructure/environments/shared-dev/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.0"
+  required_version = "0.13.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 NAME="${1:?"Please enter your name as first argument"}"
 

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -108,8 +108,15 @@ enable_analytics=false
 EOF
 	fi
 
+	# Always set the backend config, because this is always what we want
+	# and I can't imagine anyone ever hand-editing it.
+	cat >"$REPO_ROOT/infrastructure/environments/dev/backend-config.tfvars" <<EOF
+resource_group_name="$RESOURCE_GROUP_NAME"
+storage_account_name="$STORAGE_ACCOUNT_NAME"
+EOF
+
 	# terraform init is idempotent, so we might as well run it for the user.
-	cd $REPO_ROOT/infrastructure/environments/dev && terraform init -backend-config=terraform.tfvars
+	cd $REPO_ROOT/infrastructure/environments/dev && terraform init -backend-config=backend-config.tfvars
 
 	echo "Your dev terraform environment is ready to go. To initialize run:"
 	echo "("

--- a/infrastructure/scripts/create-dev-environment.sh
+++ b/infrastructure/scripts/create-dev-environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 NAME="${1:?"Please enter your name as first argument"}"
 

--- a/infrastructure/scripts/destroy-dev-environment.sh
+++ b/infrastructure/scripts/destroy-dev-environment.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd $REPO_ROOT/infrastructure/environments/dev
 
-terraform init -backend-config=terraform.tfvars
+terraform init -backend-config=backend-config.tfvars
 
 # The "uuid-ossp" Postgres extension cannot be deleted because there are tables
 # in the database using it. However it's not necessary to delete it. We can

--- a/infrastructure/scripts/install-everything.sh
+++ b/infrastructure/scripts/install-everything.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eux
 
 # https://stackoverflow.com/a/1482133
 cd $(dirname "$0")

--- a/infrastructure/scripts/install-everything.sh
+++ b/infrastructure/scripts/install-everything.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -eu
 
 # https://stackoverflow.com/a/1482133
 cd $(dirname "$0")


### PR DESCRIPTION
Updates Terraform from 0.13.0 to 0.13.3

We needed to split the `terraform.tfvars` config into 2 files - one for the backend config (`terraform init`) and one for the `terrform apply`.