### PR TITLE
fix argocd login error message from install-argo-cd.sh

### DIFF
--- a/infrastructure/scripts/install-argo-cd.sh
+++ b/infrastructure/scripts/install-argo-cd.sh
@@ -69,7 +69,7 @@ if ! argocd login --username admin --password $POD_NAME; then
 		kubectl rollout restart -n argocd deployment argocd-server
 		POD_NAME=$(kubectl get pods -n argocd | grep --only-matching 'argocd-server-[^ ]*')
 		argocd login --username admin --password $POD_NAME
-	elif argocd app list > /dev/null; then
+	elif argocd app list >/dev/null; then
 		echo "argocd has been upgraded at some point, but has kept its old password."
 		echo "if you have trouble logging in in the browser, re-run this script with"
 		echo "RESET_PASSWORD=1 to reset and print the password."

--- a/infrastructure/scripts/install-argo-cd.sh
+++ b/infrastructure/scripts/install-argo-cd.sh
@@ -63,10 +63,22 @@ export ARGOCD_OPTS='--port-forward --port-forward-namespace argocd'
 
 POD_NAME=$(kubectl get pods -n argocd | grep --only-matching 'argocd-server-[^ ]*')
 if ! argocd login --username admin --password $POD_NAME; then
-	echo "looks like argocd has been upgraded. Resetting the password."
-	KUBE_EDITOR='sed -i "" "/admin.password/d"' kubectl edit secret -n argocd argocd-secret -o json
-	kubectl rollout restart -n argocd deployment argocd-server
-	POD_NAME=$(kubectl get pods -n argocd | grep --only-matching 'argocd-server-[^ ]*')
+	if [ ${RESET_PASSWORD:-0} = 1 ]; then
+		echo "It looks like argocd has been upgraded. Resetting the password."
+		KUBE_EDITOR='sed -i "" "/admin.password/d"' kubectl edit secret -n argocd argocd-secret -o json
+		kubectl rollout restart -n argocd deployment argocd-server
+		POD_NAME=$(kubectl get pods -n argocd | grep --only-matching 'argocd-server-[^ ]*')
+		argocd login --username admin --password $POD_NAME
+	elif argocd app list > /dev/null; then
+		echo "argocd has been upgraded at some point, but has kept its old password."
+		echo "if you have trouble logging in in the browser, re-run this script with"
+		echo "RESET_PASSWORD=1 to reset and print the password."
+		exit 0
+	else
+		echo "argocd has been upgraded at some point, and we no longer know the password."
+		echo "Please re-run this script with RESET_PASSWORD=1 to reset and print the password."
+		exit 1
+	fi
 fi
 
 echo "Your argocd username for the web ui is 'admin' and password is '$POD_NAME'"


### PR DESCRIPTION
This is a bit of a hack.

The tradeoff is that it will break passwords that are stored in people's browsers, but it will make `argocd login` work if you switch to another person's cluster and back, and it will remove a warning.

It basically does what Jan suggests in docs/maintenance.md, but it does it automatically:

> Please note: We currently use the default Argo CD admin password, which is the argocd-server pod name and generated on first start. After upgrading Argo CD the pod name will change. If you want to change the password to change the new pod name, you can remove the admin.password and admin.passwordMtime keys in the argocd-secret and restart the server pod.

There is a better solution, which is to pin down the password in a sealed secret. I haven't looked into that though.