### PR TITLE
Fix frontend event types

### DIFF
--- a/.github/workflows/frontend-branch.yaml
+++ b/.github/workflows/frontend-branch.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - frontend/**
+      - event-models/**
       - infrastructure/dev-overlay-variables.json
       - .github/workflows/frontend-branch.yaml
 

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - frontend/**
+      - event-models/**
       - infrastructure/dev-overlay-variables.json
       - .github/workflows/frontend-master.yaml
 

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - workspace-service/**
+      - event-models/**
       - infrastructure/dev-overlay-variables.json
       - .github/workflows/workspace-service-branch.yaml
 jobs:

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - workspace-service/**
+      - event-models/**
       - infrastructure/dev-overlay-variables.json
       - .github/workflows/workspace-service-master.yaml
 

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -95,7 +95,8 @@
           },
           "required": ["userId", "title", "workspaceId", "folderId"]
         }
-      }
+      },
+      "required": ["eventType", "dataVersion", "data"]
     },
     "WorkspaceCreated": {
       "type": "object",

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -28,9 +28,9 @@ export interface ContentViewed {
   [k: string]: unknown;
 }
 export interface FolderCreated {
-  eventType?: "FolderCreated";
-  dataVersion?: "1";
-  data?: {
+  eventType: "FolderCreated";
+  dataVersion: "1";
+  data: {
     folderId: string;
     /**
      * The workspace that the folder is in

--- a/frontend/lib/events.test.ts
+++ b/frontend/lib/events.test.ts
@@ -19,9 +19,16 @@ describe(sendEvent, () => {
 
     test("sends event to event grid", async () => {
       await sendEvent({
+        id: "id",
         subject: "test",
-        eventType: "frontend.login.attempt",
-        data: {},
+        eventTime: "2020-01-01T12:00:00Z",
+        eventType: "ContentViewed",
+        data: {
+          contentId: "",
+          contentType: "Folder",
+          userId: "",
+          workspaceId: "",
+        },
         dataVersion: "1",
       });
 
@@ -32,9 +39,14 @@ describe(sendEvent, () => {
         {
           id: expect.any(String),
           subject: "test",
-          eventType: "frontend.login.attempt",
+          eventType: "ContentViewed",
           eventTime: expect.any(Date),
-          data: {},
+          data: {
+            contentId: "",
+            contentType: "Folder",
+            userId: "",
+            workspaceId: "",
+          },
           dataVersion: "1",
         },
       ]);
@@ -46,9 +58,16 @@ describe(sendEvent, () => {
 
     test("logs event to console", async () => {
       await sendEvent({
+        id: "id",
         subject: "test",
-        eventType: "frontend.login.attempt",
-        data: {},
+        eventTime: "2020-01-01T12:00:00Z",
+        eventType: "ContentViewed",
+        data: {
+          contentId: "",
+          contentType: "Folder",
+          userId: "",
+          workspaceId: "",
+        },
         dataVersion: "1",
       });
 

--- a/frontend/lib/events.ts
+++ b/frontend/lib/events.ts
@@ -1,24 +1,19 @@
 import { Event } from "@fnhs/event-models";
 import EventGridClient from "azure-eventgrid";
 import { TopicCredentials } from "ms-rest-azure";
-import { v4 as uuid } from "uuid";
 
 export const sendEvent = async (event: Event) => {
-  const fullEvent = {
-    id: uuid(),
-    subject: event.subject,
-    eventType: event.eventType,
-    eventTime: new Date(),
-    data: event.data,
-    dataVersion: event.dataVersion,
+  const eventGridEvent = {
+    ...event,
+    eventTime: new Date(event.eventTime),
   };
   const key = process.env.EVENTGRID_TOPIC_KEY;
   const endpoint = process.env.EVENTGRID_TOPIC_ENDPOINT;
   if (key && endpoint) {
     const client = new EventGridClient(new TopicCredentials(key));
     const topicHostname = new URL(endpoint).host;
-    await client.publishEvents(topicHostname, [fullEvent]);
+    await client.publishEvents(topicHostname, [eventGridEvent]);
   } else {
-    console.log(`EVENT: ${JSON.stringify(fullEvent)}`);
+    console.log(`EVENT: ${JSON.stringify(eventGridEvent)}`);
   }
 };


### PR DESCRIPTION
The frontend build fails: https://github.com/FutureNHS/futurenhs-platform/runs/1175766764

```
#12 10.58 ./lib/events.ts:20:48
#12 10.58 Type error: Type '{ id: string; subject: string; eventType: "ContentViewed" | "FolderCreated" | "WorkspaceCreated" | undefined; eventTime: Date; data: { [k: string]: unknown; userId: string; contentId: string; contentType: "Folder" | "File"; workspaceId: string; error?: string | undefined; } | { ...; } | { ...; } | undefined; dataVer...' is not assignable to type 'EventGridEvent'.
#12 10.58   Types of property 'eventType' are incompatible.
#12 10.58     Type 'string | undefined' is not assignable to type 'string'.
#12 10.58       Type 'undefined' is not assignable to type 'string'.
#12 10.58 
#12 10.58   18 |     const client = new EventGridClient(new TopicCredentials(key));
#12 10.58   19 |     const topicHostname = new URL(endpoint).host;
#12 10.58 > 20 |     await client.publishEvents(topicHostname, [fullEvent]);
#12 10.58      |                                                ^
#12 10.58   21 |   } else {
#12 10.58   22 |     console.log(`EVENT: ${JSON.stringify(fullEvent)}`);
#12 10.58   23 |   }
```

This fixes the types for now.

We should probably:
- Make sure we catch this on PR-build time
- Make it easier to create an event object

But we can do both of those later.