### PR TITLE
Add URL to workspace directory links

### DIFF
--- a/frontend/__tests__/pages/workspaces/__snapshots__/directory.test.tsx.snap
+++ b/frontend/__tests__/pages/workspaces/__snapshots__/directory.test.tsx.snap
@@ -137,9 +137,10 @@ exports[`takes a snapshot of the component 1`] = `
       >
         <a
           class="c6"
+          href="/workspaces/1"
         >
           <img
-            alt="https://www.nhs.co.uk"
+            alt=""
             src="/public/Placeholder_Workspace_Image.svg"
           />
           <h3>
@@ -152,9 +153,10 @@ exports[`takes a snapshot of the component 1`] = `
       >
         <a
           class="c6"
+          href="/workspaces/2"
         >
           <img
-            alt="https://www.nhs.co.uk"
+            alt=""
             src="/public/Placeholder_Workspace_Image.svg"
           />
           <h3>
@@ -167,9 +169,10 @@ exports[`takes a snapshot of the component 1`] = `
       >
         <a
           class="c6"
+          href="/workspaces/3"
         >
           <img
-            alt="https://www.nhs.co.uk"
+            alt=""
             src="/public/Placeholder_Workspace_Image.svg"
           />
           <h3>

--- a/frontend/components/Workspaces/WorkspaceDirectoryItem.tsx
+++ b/frontend/components/Workspaces/WorkspaceDirectoryItem.tsx
@@ -53,11 +53,11 @@ interface Props {
 const WorkspaceDirectoryItem = ({ title, id }: Props) => {
   return (
     <StyledContainer>
-      <Link href="/workspaces/[id]" as={`/workspaces/${id}`}>
+      <Link href="/workspaces/[id]" as={`/workspaces/${id}`} passHref>
         <StyledLink>
           <img
             src={require("../../public/Placeholder_Workspace_Image.svg")}
-            alt="https://www.nhs.co.uk"
+            alt=""
           />
           <h3>{title}</h3>
         </StyledLink>

--- a/frontend/components/Workspaces/__snapshots__/WorkspaceDirectoryItem.test.tsx.snap
+++ b/frontend/components/Workspaces/__snapshots__/WorkspaceDirectoryItem.test.tsx.snap
@@ -56,9 +56,10 @@ exports[`snapshot of component 1`] = `
   >
     <a
       class="c1"
+      href="/workspaces/test123"
     >
       <img
-        alt="https://www.nhs.co.uk"
+        alt=""
         src="/public/Placeholder_Workspace_Image.svg"
       />
       <h3>


### PR DESCRIPTION
Add a URL to workspace directory links, which makes them work without JavaScript and allows you to open them in a new tab.

Also changed the `alt` attribute on workspace directory link images to an empty string as they are purely visual and don't convey any additional information.

## Pre-review checklist

- [x] Tests

## Testing information

- Open workspace directory
- Observe that links to workspaces how have a URL when you hover.
- Try rightclicking a link and choose open in a new tab, which should now work.

## Test:

- [x] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
