### PR TITLE
Document Kubernetes upgrades

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,5 +1,16 @@
 # Maintenance
 
+## Upgrade Kubernetes
+
+Every few months we need to upgrade Kubernetes to stay in the supported version range by Azure. See [Supported Kubernetes Versions](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions) for a list of supported versions and dates.
+
+To upgrade to a new version, follow these steps:
+
+1. Update `kubernetes_version` [`infrastructure/modules/platform/variables.tf`](../infrastructure/modules/platform/variables.tf) in Terraform.
+1. Apply terraform changes.
+
+This should update the Kubernetes control plane and the default node pool.
+
 ## Upgrade Linkerd
 
 Our installation scripts always install the latest version of Linkerd. This means our dev clusters are going to stay up-to-date anyway. But since production is a long-lived environment, we need to update Linkerd manually.

--- a/infrastructure/modules/platform/main.tf
+++ b/infrastructure/modules/platform/main.tf
@@ -67,13 +67,14 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   kubernetes_version  = var.kubernetes_version
 
   default_node_pool {
-    name                = "default"
-    enable_auto_scaling = true
-    max_count           = var.kubernetes_min_node_count * 2
-    min_count           = var.kubernetes_min_node_count
-    vm_size             = "Standard_D2_v2"
-    vnet_subnet_id      = azurerm_subnet.cluster_nodes.id
-    availability_zones  = ["1", "2", "3"]
+    name                 = "default"
+    enable_auto_scaling  = true
+    max_count            = var.kubernetes_min_node_count * 2
+    min_count            = var.kubernetes_min_node_count
+    vm_size              = "Standard_D2_v2"
+    vnet_subnet_id       = azurerm_subnet.cluster_nodes.id
+    availability_zones   = ["1", "2", "3"]
+    orchestrator_version = var.kubernetes_version
     tags = {
       environment = var.environment
     }


### PR DESCRIPTION
When investigating #291, we also saw:

- The production cluster didn't autoscale. Not sure if this happened because it didn't reach it's limit, yet.
- The metrics-server had a CrashLoopBackOff.

We assume this was because the cluster control plane was running version 1.17.9 and the nodes were still on 1.15.11. To fix this, we tested node upgrades on the dev-matt cluster first. And documented how this works.

Notes:
- Does this fix the metrics server?
  Answer: Yes, it does 🙂 
- Does this fix autoscaling?
  Answer: Autoscsaling was never broken in the first place. I misinterpreted multiple crashing pods (one with OOMKilled message, which had to do with resource limits set for this pod).