### PR TITLE
Zero downtime

### DIFF
--- a/frontend/manifests/base/deployment.yaml
+++ b/frontend/manifests/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: frontend
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: frontend

--- a/frontend/manifests/base/kustomization.yaml
+++ b/frontend/manifests/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   # There is no namespace.yaml because this is managed by terraform.
   - service.yaml
   - deployment.yaml
+  - poddisruptionbudget.yaml

--- a/frontend/manifests/base/poddisruptionbudget.yaml
+++ b/frontend/manifests/base/poddisruptionbudget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: frontend

--- a/infrastructure/environments/production/main.tf
+++ b/infrastructure/environments/production/main.tf
@@ -38,14 +38,15 @@ provider "random" {}
 # These are needed before the `kubernetes` and `postgresql` terraform providers can plan
 # anything.
 module platform {
-  source                  = "../../modules/platform"
-  environment             = "production"
-  location                = var.location
-  ip_whitelist_postgresql = var.ip_whitelist_postgresql
-  ip_whitelist_analytics  = var.ip_whitelist_analytics
-  enable_analytics        = true
-  ad_username             = "FutureNHS Developers"
-  ad_object_id            = "b06ebd00-f52c-4e82-ac88-0520f4320fee"
+  source                    = "../../modules/platform"
+  environment               = "production"
+  location                  = var.location
+  ip_whitelist_postgresql   = var.ip_whitelist_postgresql
+  ip_whitelist_analytics    = var.ip_whitelist_analytics
+  enable_analytics          = true
+  ad_username               = "FutureNHS Developers"
+  ad_object_id              = "b06ebd00-f52c-4e82-ac88-0520f4320fee"
+  kubernetes_min_node_count = 2
 }
 
 resource "azurerm_container_registry" "acr" {

--- a/infrastructure/kubernetes/ingress/production/controller.yaml
+++ b/infrastructure/kubernetes/ingress/production/controller.yaml
@@ -5,18 +5,38 @@
 # There was a problem applying the default configuration using Argo CD. The certificate generation job for the admission webhook failed. Argo CD created the job before it created the role and rolebinding for the service account. This meant the job didn't have permissions to read/create Kubernetes secrets. As a workaround we've disabled the admission webhook feature for now.
 #
 # The command used to generate this file was:
-# helm template ingress-nginx -n ingress ingress-nginx/ingress-nginx --set controller.admissionWebhooks.enabled=false
+# helm template ingress-nginx -n ingress ingress-nginx/ingress-nginx --set controller.admissionWebhooks.enabled=false --set controller.replicaCount=2
 
+---
+# Source: ingress-nginx/templates/controller-poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-3.3.0
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/component: controller
+  minAvailable: 1
 ---
 # Source: ingress-nginx/templates/controller-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx
@@ -26,10 +46,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx-controller
@@ -40,10 +60,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
 rules:
@@ -110,10 +130,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
 roleRef:
@@ -130,10 +150,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx
@@ -224,10 +244,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx
@@ -245,10 +265,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx-controller
@@ -273,10 +293,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.9.0
+    helm.sh/chart: ingress-nginx-3.3.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "0.33.0"
+    app.kubernetes.io/version: "0.35.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx-controller
@@ -286,7 +306,7 @@ spec:
       app.kubernetes.io/name: ingress-nginx
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/component: controller
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   minReadySeconds: 0
   template:
@@ -299,7 +319,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0"
+          image: "k8s.gcr.io/ingress-nginx/controller:v0.35.0@sha256:fc4979d8b8443a831c9789b5155cded454cb7de737a8b727bc2ba0106d2eae8b"
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -308,10 +328,10 @@ spec:
                   - /wait-shutdown
           args:
             - /nginx-ingress-controller
-            - --publish-service=ingress/ingress-nginx-controller
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
             - --election-id=ingress-controller-leader
             - --ingress-class=nginx
-            - --configmap=ingress/ingress-nginx-controller
+            - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
           securityContext:
             capabilities:
               drop:
@@ -329,6 +349,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
           livenessProbe:
             httpGet:
               path: /healthz
@@ -338,7 +360,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /healthz

--- a/infrastructure/kubernetes/ingress/production/kustomization.yaml
+++ b/infrastructure/kubernetes/ingress/production/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
   - controller.yaml
   - ingress-frontend.yaml
 patchesStrategicMerge:
-  - patch-replicas.yaml
   - patch-dns.yaml

--- a/infrastructure/kubernetes/ingress/production/patch-replicas.yaml
+++ b/infrastructure/kubernetes/ingress/production/patch-replicas.yaml
@@ -1,6 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ingress-nginx-controller
-spec:
-  replicas: 2

--- a/infrastructure/modules/platform/main.tf
+++ b/infrastructure/modules/platform/main.tf
@@ -69,8 +69,8 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   default_node_pool {
     name                = "default"
     enable_auto_scaling = true
-    max_count           = 2
-    min_count           = 1
+    max_count           = var.kubernetes_min_node_count * 2
+    min_count           = var.kubernetes_min_node_count
     vm_size             = "Standard_D2_v2"
     vnet_subnet_id      = azurerm_subnet.cluster_nodes.id
     availability_zones  = ["1", "2", "3"]

--- a/infrastructure/modules/platform/variables.tf
+++ b/infrastructure/modules/platform/variables.tf
@@ -33,3 +33,8 @@ variable "kubernetes_version" {
   description = "Kubernetes Version"
   default     = "1.17.9"
 }
+
+variable "kubernetes_min_node_count" {
+  description = "Minimum number of Kubernetes nodes. Maximum will be this times 2"
+  default     = 1
+}

--- a/infrastructure/scripts/install-linkerd.sh
+++ b/infrastructure/scripts/install-linkerd.sh
@@ -30,7 +30,7 @@ linkerd check --pre || {
 }
 
 echo "Installing Linkerd"
-linkerd install --ha | kubectl apply -f - || {
+linkerd install | kubectl apply -f - || {
 	echo 'Unable to apply to cluster.'
 	exit 1
 }

--- a/infrastructure/scripts/install-linkerd.sh
+++ b/infrastructure/scripts/install-linkerd.sh
@@ -30,7 +30,7 @@ linkerd check --pre || {
 }
 
 echo "Installing Linkerd"
-linkerd install | kubectl apply -f - || {
+linkerd install --ha | kubectl apply -f - || {
 	echo 'Unable to apply to cluster.'
 	exit 1
 }

--- a/workspace-service/manifests/base/deployment.yaml
+++ b/workspace-service/manifests/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: workspace-service
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: workspace-service

--- a/workspace-service/manifests/base/kustomization.yaml
+++ b/workspace-service/manifests/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - poddisruptionbudget.yaml

--- a/workspace-service/manifests/base/poddisruptionbudget.yaml
+++ b/workspace-service/manifests/base/poddisruptionbudget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: workspace-service
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: workspace-service


### PR DESCRIPTION
In order to safely update the Kubernetes node pools (see #292), we need to configure our service for zero downtime. This means we need at least:

- More then 1 replica
- A PodDisruptionBudget

This PR adds those things for frontend, workspace-service, ingress.

I also made it so the production cluster has at least 2 nodes. We're reaching the capacity of one node anyway. And for uptime reasons it's better as well.

![](https://media.giphy.com/media/3o6MbnTkJL5TW9Djm8/giphy.gif)