### PR TITLE
Upgrade Kubernetes from 1.17.9 to 1.18.8

### DIFF
--- a/infrastructure/modules/platform/variables.tf
+++ b/infrastructure/modules/platform/variables.tf
@@ -31,7 +31,7 @@ variable "ad_object_id" {
 
 variable "kubernetes_version" {
   description = "Kubernetes Version"
-  default     = "1.17.9"
+  default     = "1.18.8"
 }
 
 variable "kubernetes_min_node_count" {


### PR DESCRIPTION
While I'm at it, this upgrades Kubernetes to the latest version.

Currently supported versions in AKS:
```
❯ az aks get-versions --location westeurope --output table
KubernetesVersion    Upgrades
-------------------  ------------------------
1.19.0(preview)      None available
1.18.8               1.19.0(preview)
1.18.6               1.18.8, 1.19.0(preview)
1.17.11              1.18.6, 1.18.8
1.17.9               1.17.11, 1.18.6, 1.18.8
1.16.15              1.17.9, 1.17.11
1.16.13              1.16.15, 1.17.9, 1.17.11
```