### PR TITLE
Emulate nextjs .env.local parsing better

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -66,8 +66,12 @@ const runSessionDbMigration = async (pool) => {
 async function main() {
   const dev = process.env.NODE_ENV !== "production";
   const dotEnvFileSegment = dev ? "development" : "production";
-  dotenv.config({ path: `.env.${dotEnvFileSegment}` });
+  // dotenv will never modify any environment variables that have already been set,
+  // so if values are defined in multiple places, we prefer the .local one.
+  // This is done to emulate how next.js does things.
+  dotenv.config({ path: `.env.local` });
   dotenv.config({ path: `.env.${dotEnvFileSegment}.local` });
+  dotenv.config({ path: `.env.${dotEnvFileSegment}` });
 
   const port = parseInt(process.env.PORT, 10) || 3000;
   const sessionStore = await setupSessionStore();


### PR DESCRIPTION

This allows you to put `WORKSPACE_SERVICE_GRAPHQL_ENDPOINT=http://localhost:3030/graphql` in your .env.local and run against a workspace service that is running locally.