### PR TITLE
support create-default-test-folders.sh local

### DIFF
--- a/workspace-service/scripts/create-default-test-folders.sh
+++ b/workspace-service/scripts/create-default-test-folders.sh
@@ -14,7 +14,7 @@ ENVIRONMENT="${1:?"${USAGE}Please specify your environment name as the first par
 WORKSPACE_TITLE="Selenium Testing"
 
 CURRENT_CONTEXT=$(kubectl config current-context)
-if [ "$ENVIRONMENT" != "$CURRENT_CONTEXT" ]; then
+if [[ "$ENVIRONMENT" != "local" && "$ENVIRONMENT" != "$CURRENT_CONTEXT" ]]; then
 	echo "You want to populate:    $ENVIRONMENT"
 	echo "Your current content is: $CURRENT_CONTEXT"
 	echo "Please change your current context using:"

--- a/workspace-service/scripts/create-folder-if-needed.sh
+++ b/workspace-service/scripts/create-folder-if-needed.sh
@@ -16,7 +16,11 @@ FOLDER_TITLE=${3:?"${USAGE}Please give folder title as third parameter."}
 FOLDER_DESCRIPTION=${4:-"Test folder with title $FOLDER_TITLE"}
 
 CURRENT_CONTEXT=$(kubectl config current-context)
-if [ "$ENVIRONMENT" != "$CURRENT_CONTEXT" ]; then
+if [ "$ENVIRONMENT" = "local" ]; then
+	WORKSPACE_SERVICE_GRAPHQL_ENDPOINT=http://localhost:3030/graphql
+elif [ "$ENVIRONMENT" = "$CURRENT_CONTEXT" ]; then
+	WORKSPACE_SERVICE_GRAPHQL_ENDPOINT=http://workspace-service.workspace-service/graphql
+else
 	echo "You want to populate:    $ENVIRONMENT"
 	echo "Your current content is: $CURRENT_CONTEXT"
 	echo "Please change your current context using:"
@@ -51,7 +55,7 @@ existing_folders=$(
 		--silent \
 		--show-error \
 		-XPOST \
-		http://workspace-service.workspace-service/graphql \
+		$WORKSPACE_SERVICE_GRAPHQL_ENDPOINT \
 		-H 'Content-Type: application/json' \
 		-d "$body"
 )
@@ -88,7 +92,7 @@ response=$(
 		--silent \
 		--show-error \
 		-XPOST \
-		http://workspace-service.workspace-service/graphql \
+		$WORKSPACE_SERVICE_GRAPHQL_ENDPOINT \
 		-H 'Content-Type: application/json' \
 		-d "$body"
 )

--- a/workspace-service/scripts/create-workspace-if-needed.sh
+++ b/workspace-service/scripts/create-workspace-if-needed.sh
@@ -15,7 +15,11 @@ WORKSPACE_TITLE=${2:?"${USAGE}Please give workspace title as second parameter."}
 WORKSPACE_DESCRIPTION=${3:-"Test workspace with title $WORKSPACE_TITLE"}
 
 CURRENT_CONTEXT=$(kubectl config current-context)
-if [ "$ENVIRONMENT" != "$CURRENT_CONTEXT" ]; then
+if [ "$ENVIRONMENT" = "local" ]; then
+	WORKSPACE_SERVICE_GRAPHQL_ENDPOINT=http://localhost:3030/graphql
+elif [ "$ENVIRONMENT" = "$CURRENT_CONTEXT" ]; then
+	WORKSPACE_SERVICE_GRAPHQL_ENDPOINT=http://workspace-service.workspace-service/graphql
+else
 	echo "You want to populate:    $ENVIRONMENT"
 	echo "Your current content is: $CURRENT_CONTEXT"
 	echo "Please change your current context using:"
@@ -33,7 +37,7 @@ existing_workspaces=$(
 		--silent \
 		--show-error \
 		-XPOST \
-		http://workspace-service.workspace-service/graphql \
+		$WORKSPACE_SERVICE_GRAPHQL_ENDPOINT \
 		-H 'Content-Type: application/json' \
 		-d '{"query": "{workspaces { title, id }}"}'
 )
@@ -67,7 +71,7 @@ response=$(
 		--silent \
 		--show-error \
 		-XPOST \
-		http://workspace-service.workspace-service/graphql \
+		$WORKSPACE_SERVICE_GRAPHQL_ENDPOINT \
 		-H 'Content-Type: application/json' \
 		-d "$body"
 )


### PR DESCRIPTION
In two tabs:
```
make -C workspace-service run-local
```
and
```
workspace-service/scripts/create-default-test-folders.sh local
```

This should leave you with a workspace-service running on http://localhost:3030/ with data in the db
you an add:
```
WORKSPACE_SERVICE_GRAPHQL_ENDPOINT=http://localhost:3030/graphql
```
to your frontend/.env.local to make it run against this locally-populated database.