### PR TITLE
fix frontend configmap

### DIFF
--- a/frontend/manifests/base/config-map.yaml
+++ b/frontend/manifests/base/config-map.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config_map
+  name: frontend-cm
 data:
   workspace_service_graphql_endpoint: http://workspace-service.workspace-service/graphql

--- a/frontend/manifests/base/deployment.yaml
+++ b/frontend/manifests/base/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: WORKSPACE_SERVICE_GRAPHQL_ENDPOINT
               valueFrom:
                 configMapKeyRef:
-                  name: config_map
+                  name: frontend-cm
                   key: workspace_service_graphql_endpoint
           ports:
             - containerPort: 3000


### PR DESCRIPTION
I tried deleting and recreating my cluster and I got this error:

```
GROUP        KIND                 NAMESPACE  NAME        STATUS     HEALTH   HOOK  MESSAGE
policy       PodDisruptionBudget  frontend   frontend    Synced                    poddisruptionbudget.policy/frontend unchanged
             ConfigMap            frontend   config_map  OutOfSync  Missing        ConfigMap "config_map" is invalid: metadata.name: Invalid value: "config_map": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
             Service              frontend   frontend    Synced     Healthy        service/frontend unchanged
apps         Deployment           frontend   frontend    OutOfSync  Missing        Deployment.apps "frontend" is invalid: spec.template.spec.containers[0].env[8].valueFrom.configMapKeyRef.name: Invalid value: "config_map": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
bitnami.com  SealedSecret         frontend   sessions    Synced                    sealedsecret.bitnami.com/sessions unchanged
FATA[0383] timed out (300s) waiting for app "frontend" match desired state 
```

I think that Potts might have also had this problem.

I tested it out with `./infrastructure/scripts/install-argo-cd.sh dev-david pr-fix-frontend-configmap` and it seems to work.

<img src="https://media.giphy.com/media/LT0QGQkX9puTkemVuK/giphy-downsized.gif"/>