### PR TITLE
Mock Urql client

### DIFF
--- a/frontend/__tests__/pages/workspaces/[workspaceId].test.tsx
+++ b/frontend/__tests__/pages/workspaces/[workspaceId].test.tsx
@@ -1,52 +1,47 @@
 import React from "react";
 
 import { ThemeProvider } from "styled-components";
-import { fromValue, never } from "wonka";
 
 import theme from "../../../lib/fixtures/theme.json";
+import {
+  FoldersByWorkspaceDocument,
+  GetWorkspaceByIdDocument,
+} from "../../../lib/generated/graphql";
 import { render } from "../../../lib/test-helpers/render";
+import { mockUrqlClient } from "../../../lib/test-helpers/urql";
 import WorkspaceHomepage from "../../../pages/workspaces/[workspaceId]";
 
 describe(WorkspaceHomepage, () => {
-  const responseState = {
-    executeQuery: jest.fn(({ query }) => {
-      if (
-        query.definitions.find((d: any) => d.name.value == "GetWorkspaceByID")
-      ) {
-        return fromValue({
-          data: {
-            workspace: {
-              id: "1",
-              title: "hospital",
-            },
+  const client = mockUrqlClient([
+    [
+      GetWorkspaceByIdDocument,
+      {
+        workspace: {
+          id: "1",
+          title: "hospital",
+          description: "test",
+        },
+      },
+    ],
+    [
+      FoldersByWorkspaceDocument,
+      {
+        foldersByWorkspace: [
+          {
+            id: "f1",
+            title: "folder 1",
+            description: "first folder",
+            workspace: "1",
           },
-        });
-      }
-      if (
-        query.definitions.find((d: any) => d.name.value == "FoldersByWorkspace")
-      ) {
-        return fromValue({
-          data: {
-            foldersByWorkspace: [
-              {
-                id: "f1",
-                title: "folder 1",
-                description: "first folder",
-                workspace: "1",
-              },
-            ],
-          },
-        });
-      }
-    }),
-    executeMutation: jest.fn(() => never),
-    executeSubscription: jest.fn(() => never),
-  };
+        ],
+      },
+    ],
+  ]);
 
   test("renders with folders matching snapshot", () => {
     const container = render(
       <ThemeProvider theme={theme}>
-        <WorkspaceHomepage urqlClient={responseState} />
+        <WorkspaceHomepage urqlClient={client} />
       </ThemeProvider>,
       {
         router: {

--- a/frontend/__tests__/pages/workspaces/[workspaceId]/folders/[folderId].test.tsx
+++ b/frontend/__tests__/pages/workspaces/[workspaceId]/folders/[folderId].test.tsx
@@ -1,64 +1,59 @@
 import React from "react";
 
 import { ThemeProvider } from "styled-components";
-import { fromValue, never } from "wonka";
 
 import theme from "../../../../../lib/fixtures/theme.json";
+import {
+  FoldersByWorkspaceDocument,
+  GetFolderByIdDocument,
+  GetWorkspaceByIdDocument,
+} from "../../../../../lib/generated/graphql";
 import { render } from "../../../../../lib/test-helpers/render";
+import { mockUrqlClient } from "../../../../../lib/test-helpers/urql";
 import FolderHomepage from "../../../../../pages/workspaces/[workspaceId]/folders/[folderId]";
 
 describe(FolderHomepage, () => {
-  const responseState = {
-    executeQuery: jest.fn(({ query }) => {
-      if (
-        query.definitions.find((d: any) => d.name.value == "GetWorkspaceByID")
-      ) {
-        return fromValue({
-          data: {
-            workspace: {
-              id: "1",
-              title: "hospital",
-            },
+  const client = mockUrqlClient([
+    [
+      GetWorkspaceByIdDocument,
+      {
+        workspace: {
+          id: "1",
+          title: "hospital",
+          description: "hospital",
+        },
+      },
+    ],
+    [
+      GetFolderByIdDocument,
+      {
+        folder: {
+          id: "f1",
+          title: "folder 1",
+          description: "first folder",
+          workspace: "1",
+        },
+      },
+    ],
+    [
+      FoldersByWorkspaceDocument,
+      {
+        foldersByWorkspace: [
+          {
+            id: "f1",
+            title: "folder 1",
+            description: "first folder",
+            workspace: "1",
           },
-        });
-      }
-      if (query.definitions.find((d: any) => d.name.value == "GetFolderById")) {
-        return fromValue({
-          data: {
-            folder: {
-              id: "f1",
-              title: "folder 1",
-              description: "first folder",
-              workspace: "1",
-            },
-          },
-        });
-      }
-      if (
-        query.definitions.find((d: any) => d.name.value == "FoldersByWorkspace")
-      ) {
-        return fromValue({
-          data: {
-            foldersByWorkspace: [
-              {
-                id: "f1",
-                title: "folder 1",
-                description: "first folder",
-                workspace: "1",
-              },
-            ],
-          },
-        });
-      }
-    }),
-    executeMutation: jest.fn(() => never),
-    executeSubscription: jest.fn(() => never),
-  };
+        ],
+      },
+    ],
+  ]);
 
   test("renders matching snapshot", () => {
     const container = render(
       <ThemeProvider theme={theme}>
-        <FolderHomepage urqlClient={responseState} />
+        <FolderHomepage urqlClient={client} />
       </ThemeProvider>,
       {
         router: {

--- a/frontend/__tests__/pages/workspaces/directory.test.tsx
+++ b/frontend/__tests__/pages/workspaces/directory.test.tsx
@@ -2,31 +2,29 @@ import React from "react";
 
 import { render } from "@testing-library/react";
 import { ThemeProvider } from "styled-components";
-import { fromValue, never } from "wonka";
 
 import theme from "../../../lib/fixtures/theme.json";
+import { GetWorkspacesDocument } from "../../../lib/generated/graphql";
+import { mockUrqlClient } from "../../../lib/test-helpers/urql";
 import WorkspaceDirectory from "../../../pages/workspaces/directory";
 
 test("takes a snapshot of the component", () => {
-  const responseState = {
-    executeQuery: jest.fn(() =>
-      fromValue({
-        data: {
-          workspaces: [
-            { title: "hospital", id: "1" },
-            { title: "pharmacy", id: "2" },
-            { title: "ambulance", id: "3" },
-          ],
-        },
-      })
-    ),
-    executeMutation: jest.fn(() => never),
-    executeSubscription: jest.fn(() => never),
-  };
+  const client = mockUrqlClient([
+    [
+      GetWorkspacesDocument,
+      {
+        workspaces: [
+          { title: "hospital", id: "1", description: "hospital" },
+          { title: "pharmacy", id: "2", description: "pharmacy" },
+          { title: "ambulance", id: "3", description: "ambulance" },
+        ],
+      },
+    ],
+  ]);
 
   const { asFragment } = render(
     <ThemeProvider theme={theme}>
-      <WorkspaceDirectory urqlClient={responseState} />
+      <WorkspaceDirectory urqlClient={client} />
     </ThemeProvider>
   );
   expect(asFragment()).toMatchSnapshot();

--- a/frontend/components/Navigation/Navigation.test.tsx
+++ b/frontend/components/Navigation/Navigation.test.tsx
@@ -3,30 +3,39 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { ThemeProvider } from "styled-components";
 import { Provider } from "urql";
-import { fromValue, never } from "wonka";
 
 import theme from "../../lib/fixtures/theme.json";
+import { FoldersByWorkspaceDocument } from "../../lib/generated/graphql";
+import { mockUrqlClient } from "../../lib/test-helpers/urql";
 import Navigation from "./Navigation";
 
 describe.only("<Navigation/>", () => {
-  const responseState = {
-    executeQuery: jest.fn(() =>
-      fromValue({
-        data: {
-          foldersByWorkspace: [
-            { id: "1234", title: "Folder 1" },
-            { id: "5678", title: "Folder 2" },
-          ],
-        },
-      })
-    ),
-    executeMutation: jest.fn(() => never),
-    executeSubscription: jest.fn(() => never),
-  };
+  const client = mockUrqlClient([
+    [
+      FoldersByWorkspaceDocument,
+      {
+        foldersByWorkspace: [
+          {
+            id: "1234",
+            title: "Folder 1",
+            description: "Folder 1",
+            workspace: "1111",
+          },
+          {
+            id: "5678",
+            title: "Folder 2",
+            description: "Folder 2",
+            workspace: "1111",
+          },
+        ],
+      },
+    ],
+  ]);
+
   it("renders correctly", () => {
     const container = render(
       <ThemeProvider theme={theme}>
-        <Provider value={responseState}>
+        <Provider value={client}>
           <Navigation workspaceId="1111" workspaceTitle="My workspace" />
         </Provider>
       </ThemeProvider>

--- a/frontend/lib/test-helpers/urql.ts
+++ b/frontend/lib/test-helpers/urql.ts
@@ -1,0 +1,31 @@
+import { DocumentNode } from "graphql";
+import { makeResult, Client, Operation, createClient } from "urql";
+import { fromValue } from "wonka";
+
+import { Query } from "../generated/graphql";
+
+export type MockUrqlClient = (
+  queries: Array<[DocumentNode, Partial<Query>]>
+) => Client;
+
+export const mockUrqlClient: MockUrqlClient = (queries) => {
+  const client = createClient({ url: "http://localhost", exchanges: [] });
+  return Object.assign(client, {
+    executeQuery: jest.fn(({ query }) => {
+      const operation: Operation = {
+        context: {} as any,
+        key: 1,
+        operationName: "query",
+        query,
+      };
+      const data = queries.find((q) => q[0] === query);
+      return fromValue(
+        data
+          ? makeResult(operation, { data: data[1] })
+          : makeResult(operation, {
+              error: "query not found",
+            })
+      );
+    }),
+  });
+};

--- a/frontend/pages/workspaces/[workspaceId].tsx
+++ b/frontend/pages/workspaces/[workspaceId].tsx
@@ -36,10 +36,11 @@ const WorkspaceHomepage: NextPage = () => {
     variables: { id },
   });
 
-  const workspaceTitle = data?.workspace.title || "No title!";
+  const workspaceTitle = (!fetching && data?.workspace.title) || "Loading...";
+
   return (
     <>
-      <Head title={fetching ? "Loading..." : workspaceTitle} />
+      <Head title={workspaceTitle} />
       <PageLayout>
         <NavHeader />
         <ContentWrapper>


### PR DESCRIPTION
This PR adds a mock Urql client that we can use in our tests. It provides a strongly typed interface for specifying data to be returned during the test run.