### PR TITLE
Allow Data Factory access to analytics DB

### DIFF
--- a/infrastructure/modules/platform/analytics.tf
+++ b/infrastructure/modules/platform/analytics.tf
@@ -186,6 +186,14 @@ resource "azurerm_sql_database" "analytics_data_warehouse" {
   }
 }
 
+resource "azurerm_sql_firewall_rule" "allow_azure_services" {
+  name                = "allow-azure-services"
+  resource_group_name = azurerm_resource_group.platform.name
+  server_name         = azurerm_mssql_server.analytics[0].name
+  start_ip_address    = "0.0.0.0"
+  end_ip_address      = "0.0.0.0"
+}
+
 resource "azurerm_sql_firewall_rule" "allow_ip" {
   for_each            = var.enable_analytics ? var.ip_whitelist_analytics : {}
   name                = "allow-ip-${each.key}"


### PR DESCRIPTION
Allow Azure Integration Runtime of Data Factory access to analytics DB
by adding a Firewall rule, which allows access from all Azure Services.
In theory we could limit IP to address ranges used by the Integration
Runtime. However they can in theory change on a weekly basis and keeping
up with this seems like too much effort at the moment.

See also: https://docs.microsoft.com/en-gb/azure/data-factory/azure-integration-runtime-ip-addresses