### PR TITLE
Update method to set env var in GitHub Actions

### DIFF
--- a/.github/workflows/frontend-branch.yaml
+++ b/.github/workflows/frontend-branch.yaml
@@ -56,8 +56,8 @@ jobs:
           make docker-build tag=${TAG}
           make docker-push tag=${TAG}
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ secrets.REGISTRY_LOGIN_SERVER }}/frontend:${TAG})"
-          echo ::set-env name=TAG::$TAG
-          echo ::set-env name=DIGEST::$DIGEST
+          echo "TAG=$TAG" >>$GITHUB_ENV
+          echo "DIGEST=$DIGEST" >>$GITHUB_ENV
 
       - name: Clone Deployments repo
         uses: actions/checkout@v2

--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -56,8 +56,8 @@ jobs:
           make docker-build tag=${TAG}
           make docker-push tag=${TAG}
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ secrets.REGISTRY_LOGIN_SERVER }}/frontend:${TAG})"
-          echo ::set-env name=TAG::$TAG
-          echo ::set-env name=DIGEST::$DIGEST
+          echo "TAG=$TAG" >>$GITHUB_ENV
+          echo "DIGEST=$DIGEST" >>$GITHUB_ENV
 
       - name: Clone Deployments repo
         uses: actions/checkout@v2

--- a/.github/workflows/infrastructure-branch.yaml
+++ b/.github/workflows/infrastructure-branch.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euxo pipefail
           git fetch origin HEAD --deepen=2
-          echo ::set-env name=COMMIT_MESSAGE::$(git log --format=%B -n 1 ${{ github.event.after }})
+          echo "COMMIT_MESSAGE=$(git log --format=%B -n 1 ${{ github.event.after }})" >>$GITHUB_ENV
       - name: Clone Deployments repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -78,8 +78,8 @@ jobs:
           make docker-build tag=${TAG}
           make docker-push tag=${TAG}
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ secrets.REGISTRY_LOGIN_SERVER }}/workspace-service:${TAG})"
-          echo ::set-env name=TAG::$TAG
-          echo ::set-env name=DIGEST::$DIGEST
+          echo "TAG=$TAG" >>$GITHUB_ENV
+          echo "DIGEST=$DIGEST" >>$GITHUB_ENV
       - name: Clone Deployments repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -79,8 +79,8 @@ jobs:
           make docker-build tag=${TAG}
           make docker-push tag=${TAG}
           DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' ${{ secrets.REGISTRY_LOGIN_SERVER }}/workspace-service:${TAG})"
-          echo ::set-env name=TAG::$TAG
-          echo ::set-env name=DIGEST::$DIGEST
+          echo "TAG=$TAG" >>$GITHUB_ENV
+          echo "DIGEST=$DIGEST" >>$GITHUB_ENV
       - name: Clone Deployments repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The old method (writing ::set-env to stdout) had a security
vulnerability. See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

GitHub actions now provides a new way of setting environment variables,
that can be used by later steps in the workflow. It works by writing the
desired variable to a temporary file. This updates all our workflows to
use this new method.