### PR TITLE
1817 create user table and user mutations

### DIFF
--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -342,6 +342,45 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "NewUser",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "authId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "NewWorkspace",
         "description": null,
         "fields": null,
@@ -408,6 +447,45 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UpdateUser",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "authId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "isPlatformAdmin",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -860,6 +938,37 @@
             "deprecationReason": null
           },
           {
+            "name": "getOrCreateUser",
+            "description": "Get or Create a new user (returns the user)",
+            "args": [
+              {
+                "name": "newUser",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "NewUser",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updateFolder",
             "description": "Update folder (returns updated folder",
             "args": [
@@ -898,6 +1007,37 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Folder",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateUser",
+            "description": "Update a user (returns the user)",
+            "args": [
+              {
+                "name": "updateUser",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdateUser",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
                 "ofType": null
               }
             },
@@ -1225,6 +1365,81 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "User",
+        "description": "A user",
+        "fields": [
+          {
+            "name": "authId",
+            "description": "The auth id of the user",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The id of the user",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPlatformAdmin",
+            "description": "If true, user has full platform access",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the user",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/workspace-service/migrations/20201009093453_create_user_table.sql
+++ b/workspace-service/migrations/20201009093453_create_user_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS users (
+    id uuid DEFAULT uuid_generate_v4 (),
+    auth_id uuid UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    is_platform_admin BOOLEAN NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/workspace-service/sql/users/get_or_create.sql
+++ b/workspace-service/sql/users/get_or_create.sql
@@ -1,0 +1,6 @@
+INSERT INTO users (auth_id, name, is_platform_admin)
+VALUES ($1, $2, FALSE)
+ON CONFLICT (auth_id) DO UPDATE
+-- Noop; sql syntax to allow return without use of Option type
+    SET name = users.name
+RETURNING *;

--- a/workspace-service/sql/users/update.sql
+++ b/workspace-service/sql/users/update.sql
@@ -1,0 +1,4 @@
+UPDATE users
+SET is_platform_admin = $2
+WHERE auth_id = $1
+RETURNING *

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -150,6 +150,45 @@
       ]
     }
   },
+  "3588b04670ed16bc2dc9ddb7d791336923afaee153fdcce2bee466c8c8c390b2": {
+    "query": "INSERT INTO users (auth_id, name, is_platform_admin)\nVALUES ($1, $2, FALSE)\nON CONFLICT (auth_id) DO UPDATE\n-- Noop; sql syntax to allow return without use of Option type\n    SET name = users.name\nRETURNING *;\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "auth_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_platform_admin",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "44b91b63dbd034f908add2ff7a3e9eace7a2cd8f625ca0e180d37f872ce26b22": {
     "query": "UPDATE workspaces\nSET title = COALESCE($2, title),\n    description = COALESCE($3, description)\nWHERE id = $1\nRETURNING id, title, description\n",
     "describe": {
@@ -576,6 +615,45 @@
         ]
       },
       "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "fab511bd36333130a3994817dd646ad8f2ebeff05f66eadd663741cff69440a9": {
+    "query": "UPDATE users\nSET is_platform_admin = $2\nWHERE auth_id = $1\nRETURNING *\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "auth_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_platform_admin",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Bool"
+        ]
+      },
+      "nullable": [
+        false,
         false,
         false,
         false

--- a/workspace-service/src/db.rs
+++ b/workspace-service/src/db.rs
@@ -292,3 +292,29 @@ impl File {
         Ok(file)
     }
 }
+
+#[derive(Clone)]
+pub struct User {
+    pub id: Uuid,
+    pub auth_id: Uuid,
+    pub name: String,
+    pub is_platform_admin: bool,
+}
+
+impl User {
+    pub async fn get_or_create(auth_id: &Uuid, name: &str, pool: &PgPool) -> Result<User> {
+        let user = sqlx::query_file_as!(User, "sql/users/get_or_create.sql", auth_id, name)
+            .fetch_one(pool)
+            .await?;
+
+        Ok(user)
+    }
+
+    pub async fn update(auth_id: &Uuid, is_platform_admin: &bool, pool: &PgPool) -> Result<User> {
+        let user = sqlx::query_file_as!(User, "sql/users/update.sql", auth_id, is_platform_admin)
+            .fetch_one(pool)
+            .await?;
+
+        Ok(user)
+    }
+}

--- a/workspace-service/src/graphql/mod.rs
+++ b/workspace-service/src/graphql/mod.rs
@@ -4,6 +4,7 @@ mod folders;
 mod schema;
 #[cfg(test)]
 mod test_mocks;
+mod users;
 mod workspaces;
 
 use super::db;
@@ -48,6 +49,7 @@ struct Mutation(
     folders::FoldersMutation,
     workspaces::WorkspacesMutation,
     files::FilesMutation,
+    users::UsersMutation,
 );
 
 pub async fn handle_healthz(req: Request<State>) -> tide::Result {

--- a/workspace-service/src/graphql/users.rs
+++ b/workspace-service/src/graphql/users.rs
@@ -1,0 +1,73 @@
+use super::db;
+use async_graphql::{Context, FieldResult, InputObject, Object, SimpleObject, ID};
+use uuid::Uuid;
+
+#[SimpleObject(desc = "A user")]
+pub struct User {
+    #[field(desc = "The id of the user")]
+    pub id: ID,
+    #[field(desc = "The auth id of the user")]
+    pub auth_id: ID,
+    #[field(desc = "The name of the user")]
+    pub name: String,
+    #[field(desc = "If true, user has full platform access")]
+    pub is_platform_admin: bool,
+}
+
+#[InputObject]
+pub struct NewUser {
+    pub auth_id: ID,
+    pub name: String,
+}
+
+#[InputObject]
+pub struct UpdateUser {
+    pub auth_id: ID,
+    pub is_platform_admin: bool,
+}
+
+impl From<db::User> for User {
+    fn from(d: db::User) -> Self {
+        Self {
+            id: d.id.into(),
+            name: d.name,
+            auth_id: d.auth_id.into(),
+            is_platform_admin: d.is_platform_admin,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct UsersMutation;
+
+#[Object]
+impl UsersMutation {
+    #[field(desc = "Get or Create a new user (returns the user)")]
+    async fn get_or_create_user(
+        &self,
+        context: &Context<'_>,
+        new_user: NewUser,
+    ) -> FieldResult<User> {
+        let pool = context.data()?;
+        let auth_id = Uuid::parse_str(&new_user.auth_id)?;
+
+        Ok(db::User::get_or_create(&auth_id, &new_user.name, pool)
+            .await?
+            .into())
+    }
+    #[field(desc = "Update a user (returns the user)")]
+    async fn update_user(
+        &self,
+        context: &Context<'_>,
+        update_user: UpdateUser,
+    ) -> FieldResult<User> {
+        let pool = context.data()?;
+        let auth_id = Uuid::parse_str(&update_user.auth_id)?;
+
+        Ok(
+            db::User::update(&auth_id, &update_user.is_platform_admin, pool)
+                .await?
+                .into(),
+        )
+    }
+}


### PR DESCRIPTION
[Ticket](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/1817/)

![](https://media.giphy.com/media/xT5LMNcQceSPpA2BeU/giphy.gif)

This PR is contains the workspace service work required to create a user record in our DB and update with `is_platform_admin` permissions where appropriate. This enables us to lock down parts of the `frontend` based on whether this field is `true` or `false` for a user. 

- `getOrCreateUser` is an idempotent operation for creating a new user with a unique GUID only once, fetching it where it already exists.
- `updateUser` is predominantly for changing the value of the `is_platform_admin` field to `true` or `false`, depending if we are granting or revoking permissions.

## Acceptance Criteria

- Create a new User table in Workspace Service with `auth_id` and `is_platform_admin` fields.
- `GetOrCreate` and `Update` mutations are completed.

## Pre-review checklist:

- [ ] Tests

- [x] Documentation

- [ ] ~~Analytics (user analytics, e.g. Google Analytics)~~

- [x] Observability (metrics/tracing)

- [ ] ~~Feature flag~~

- [x] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?

👎 

- Test plan?

Start up the local workspace service with `make run-local`. navigate to `http://localhost:3030/graphiql` and run the `getOrCreateUser` and `updateUser` mutations. 

## Test:

- [x] Tested locally
