### PR TITLE
Forward x-user-auth-id header to workspace-service

### DIFF
--- a/frontend/cypress/fixtures/get-or-create-user-graphql-response.json
+++ b/frontend/cypress/fixtures/get-or-create-user-graphql-response.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "getOrCreateUser": {
+      "id": "073d9a5d-33a7-4a0f-ae78-ce93f48c6ae3",
+      "name": "Local User",
+      "authId": "0c8109ef-c247-4c41-b679-000000000000",
+      "isPlatformAdmin": false,
+      "__typename": "User"
+    }
+  }
+}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,5 +1,5 @@
 export interface User {
-  id: string;
+  authId: string;
   name: string;
   emails: string[];
 }

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -2,4 +2,5 @@ export interface User {
   authId: string;
   name: string;
   emails: string[];
+  isPlatformAdmin: boolean;
 }

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,4 +1,5 @@
 export interface User {
+  id: string;
   authId: string;
   name: string;
   emails: string[];

--- a/frontend/lib/requireEnv.ts
+++ b/frontend/lib/requireEnv.ts
@@ -1,5 +1,4 @@
 export const requireEnv = (name: string) => {
-  console.log(process.env[name], name);
   const value = process.env[name];
   if (!value) {
     throw new Error(`Environment variable ${name} is required`);

--- a/frontend/lib/server/README.md
+++ b/frontend/lib/server/README.md
@@ -1,0 +1,5 @@
+# server.js helpers
+
+These js files are available at startup time from javascript (no typescript imports allowed).
+
+Use JSDoc comments to add types if you want to import from typescript code.

--- a/frontend/lib/server/graphql.js
+++ b/frontend/lib/server/graphql.js
@@ -6,30 +6,22 @@ const client = createClient({
 });
 
 const getOrCreateUser = async ({ authId, name }) => {
-  try {
-    const reqBody = gql`
-      mutation($authId: ID!, $name: String!) {
-        getOrCreateUser(newUser: { authId: $authId, name: $name }) {
-          id
-          name
-          authId
-          isPlatformAdmin
-        }
+  const query = gql`
+    mutation($authId: ID!, $name: String!) {
+      getOrCreateUser(newUser: { authId: $authId, name: $name }) {
+        id
+        name
+        authId
+        isPlatformAdmin
       }
-    `;
+    }
+  `;
 
-    return await client
-      .mutation(reqBody, { authId, name })
-      .toPromise()
-      .then((result) => {
-        if (result.error) {
-          throw result.error;
-        } else {
-          return result.data;
-        }
-      });
-  } catch (err) {
-    console.log("getOrCreateUser Error: ", err);
+  const result = await client.mutation(query, { authId, name }).toPromise();
+  if (result.error) {
+    throw result.error;
+  } else {
+    return result.data;
   }
 };
 

--- a/frontend/lib/server/graphql.js
+++ b/frontend/lib/server/graphql.js
@@ -1,0 +1,38 @@
+const gql = require("graphql-tag");
+const { createClient } = require("urql");
+
+const client = createClient({
+  url: "http://localhost:3030/graphql",
+});
+
+const getOrCreateUser = async ({ authId, name }) => {
+  try {
+    const reqBody = gql`
+      mutation($authId: ID!, $name: String!) {
+        getOrCreateUser(newUser: { authId: $authId, name: $name }) {
+          id
+          name
+          authId
+          isPlatformAdmin
+        }
+      }
+    `;
+
+    return await client
+      .mutation(reqBody, { authId, name })
+      .toPromise()
+      .then((result) => {
+        if (result.error) {
+          throw result.error;
+        } else {
+          return result.data;
+        }
+      });
+  } catch (err) {
+    console.log("getOrCreateUser Error: ", err);
+  }
+};
+
+module.exports = {
+  getOrCreateUser,
+};

--- a/frontend/lib/server/graphql.js
+++ b/frontend/lib/server/graphql.js
@@ -1,11 +1,12 @@
 const gql = require("graphql-tag");
 const { createClient } = require("urql");
 
-const client = createClient({
-  url: "http://localhost:3030/graphql",
-});
+const { requireEnv } = require("./requireEnv");
 
 const getOrCreateUser = async ({ authId, name }) => {
+  const client = createClient({
+    url: requireEnv("WORKSPACE_SERVICE_GRAPHQL_ENDPOINT"),
+  });
   const query = gql`
     mutation($authId: ID!, $name: String!) {
       getOrCreateUser(newUser: { authId: $authId, name: $name }) {

--- a/frontend/lib/server/noop-passport-strategy.js
+++ b/frontend/lib/server/noop-passport-strategy.js
@@ -2,7 +2,7 @@ const util = require("util");
 
 const passport = require("passport-strategy");
 
-const { getOrCreateUser } = require("./lib/server/graphql");
+const { getOrCreateUser } = require("./graphql");
 
 function Strategy() {
   passport.Strategy.call(this);
@@ -10,17 +10,19 @@ function Strategy() {
 
 util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = async function () {
-  const testAuthId = "0c8109ef-c247-4c41-b679-b609866487b9";
+  // Test value that's an auto generated V4 UUID
+  const testAuthId = "0c8109ef-c247-4c41-b679-000000000000";
   const testName = "Local User";
+
   const response = await getOrCreateUser({
     authId: testAuthId,
     name: testName,
   });
-  const {
-    getOrCreateUser: { name, authId, is_platform_admin: isPlatformAdmin },
-  } = response;
-  var self = this;
-  self.success({
+
+  const { id, name, authId, isPlatformAdmin } = response.getOrCreateUser;
+
+  this.success({
+    id,
     authId,
     name,
     isPlatformAdmin,

--- a/frontend/lib/server/noop-passport-strategy.js
+++ b/frontend/lib/server/noop-passport-strategy.js
@@ -10,24 +10,28 @@ function Strategy() {
 
 util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = async function () {
-  // Test value that's an auto generated V4 UUID
-  const testAuthId = "0c8109ef-c247-4c41-b679-000000000000";
-  const testName = "Local User";
+  try {
+    // Test value that's an auto generated V4 UUID
+    const testAuthId = "0c8109ef-c247-4c41-b679-000000000000";
+    const testName = "Local User";
 
-  const response = await getOrCreateUser({
-    authId: testAuthId,
-    name: testName,
-  });
+    const response = await getOrCreateUser({
+      authId: testAuthId,
+      name: testName,
+    });
 
-  const { id, name, authId, isPlatformAdmin } = response.getOrCreateUser;
+    const { id, name, authId, isPlatformAdmin } = response.getOrCreateUser;
 
-  this.success({
-    id,
-    authId,
-    name,
-    isPlatformAdmin,
-    emails: ["test@example.com"],
-  });
+    this.success({
+      id,
+      authId,
+      name,
+      isPlatformAdmin,
+      emails: ["test@example.com"],
+    });
+  } catch (err) {
+    this.error(err);
+  }
 };
 
 module.exports = Strategy;

--- a/frontend/lib/server/requireEnv.js
+++ b/frontend/lib/server/requireEnv.js
@@ -1,4 +1,10 @@
-export const requireEnv = (name: string) => {
+// @ts-check
+
+/**
+ * @param {string} name
+ * @returns {string}
+ */
+const requireEnv = (name) => {
   const value = process.env[name];
   if (!value) {
     throw new Error(`Environment variable ${name} is required`);
@@ -6,3 +12,5 @@ export const requireEnv = (name: string) => {
 
   return value;
 };
+
+module.exports = { requireEnv };

--- a/frontend/lib/withUrqlClient.ts
+++ b/frontend/lib/withUrqlClient.ts
@@ -10,7 +10,7 @@ import {
   FoldersByWorkspaceDocument,
   FoldersByWorkspaceQuery,
 } from "./generated/graphql";
-import { requireEnv } from "./requireEnv";
+import { requireEnv } from "./server/requireEnv";
 
 const isServerSide = typeof window === "undefined";
 const workspaceAPIServerUrl = isServerSide

--- a/frontend/noop-passport-strategy.js
+++ b/frontend/noop-passport-strategy.js
@@ -2,16 +2,28 @@ const util = require("util");
 
 const passport = require("passport-strategy");
 
+const { getOrCreateUser } = require("./lib/server/graphql");
+
 function Strategy() {
   passport.Strategy.call(this);
 }
 
 util.inherits(Strategy, passport.Strategy);
-Strategy.prototype.authenticate = function () {
+Strategy.prototype.authenticate = async function () {
+  const testAuthId = "0c8109ef-c247-4c41-b679-b609866487b9";
+  const testName = "Local User";
+  const response = await getOrCreateUser({
+    authId: testAuthId,
+    name: testName,
+  });
+  const {
+    getOrCreateUser: { name, authId, is_platform_admin: isPlatformAdmin },
+  } = response;
   var self = this;
   self.success({
-    authId: "test",
-    name: "Local User",
+    authId,
+    name,
+    isPlatformAdmin,
     emails: ["test@example.com"],
   });
 };

--- a/frontend/noop-passport-strategy.js
+++ b/frontend/noop-passport-strategy.js
@@ -10,7 +10,7 @@ util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = function () {
   var self = this;
   self.success({
-    id: "test",
+    authId: "test",
     name: "Local User",
     emails: ["test@example.com"],
   });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.2",
     "@types/node-fetch": "^2.5.7",
+    "@types/passport-strategy": "^0.2.35",
     "@types/react": "^16.9.50",
     "@types/styled-components": "^5.1.3",
     "@types/testing-library__jest-dom": "^5.9.3",

--- a/frontend/pages/api/graphql.ts
+++ b/frontend/pages/api/graphql.ts
@@ -3,7 +3,7 @@ import { ApolloServer } from "apollo-server-micro";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { User } from "../../lib/auth";
-import { requireEnv } from "../../lib/requireEnv";
+import { requireEnv } from "../../lib/server/requireEnv";
 
 const workspaceAPIServerUrl = requireEnv("WORKSPACE_SERVICE_GRAPHQL_ENDPOINT");
 

--- a/frontend/pages/api/graphql.ts
+++ b/frontend/pages/api/graphql.ts
@@ -17,12 +17,11 @@ const gateway = new ApolloGateway({
   buildService: ({ url }) =>
     new RemoteGraphQLDataSource({
       url,
-      willSendRequest({ request, context }) {
+      willSendRequest: ({ context, request }): void => {
         // context will be empty for schema requests
-        console.log("xxx", context);
-        const userId = context.user?.id;
-        if (userId) {
-          request.http?.headers.set("x-user-id", userId);
+        const authId = context.user?.authId;
+        if (authId) {
+          request.http?.headers.set("x-user-auth-id", authId);
         }
       },
     }),

--- a/frontend/pages/api/health.ts
+++ b/frontend/pages/api/health.ts
@@ -4,6 +4,7 @@ const requiredEnvVars = [
   "EVENTGRID_TOPIC_ENDPOINT",
   "EVENTGRID_TOPIC_KEY",
   "PG_URL",
+  "WORKSPACE_SERVICE_GRAPHQL_ENDPOINT",
 ];
 
 export default (_: NextApiRequest, res: NextApiResponse) => {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -121,7 +121,7 @@ async function main() {
           },
           (profile, done) => {
             done(null, {
-              id: profile.sub,
+              authId: profile.sub,
               name: profile.displayName,
               emails: profile.emails,
             });

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -12,15 +12,7 @@ const Noop = require("./lib/server/noop-passport-strategy");
 const url = require("url");
 const { promises: fs } = require("fs");
 const { getOrCreateUser } = require("./lib/server/graphql");
-
-const requireEnv = (name) => {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Environment variable ${name} is required`);
-  }
-
-  return value;
-};
+const { requireEnv } = require("./lib/server/requireEnv");
 
 const setupSessionStore = async () => {
   const pgUrl = process.env.PG_URL;

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -113,23 +113,27 @@ async function main() {
             isB2C: true,
           },
           async (profile, done) => {
-            const response = await getOrCreateUser({
-              authId: profile.sub,
-              name: profile.displayName,
-            });
-            const {
-              id,
-              name,
-              authId,
-              isPlatformAdmin,
-            } = response.getOrCreateUser;
-            done(null, {
-              id,
-              authId,
-              name,
-              isPlatformAdmin,
-              emails: profile.emails,
-            });
+            try {
+              const response = await getOrCreateUser({
+                authId: profile.sub,
+                name: profile.displayName,
+              });
+              const {
+                id,
+                name,
+                authId,
+                isPlatformAdmin,
+              } = response.getOrCreateUser;
+              done(null, {
+                id,
+                authId,
+                name,
+                isPlatformAdmin,
+                emails: profile.emails,
+              });
+            } catch (err) {
+              done(err);
+            }
           }
         )
   );

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -11,6 +11,7 @@ const Noop = require("./noop-passport-strategy");
 
 const url = require("url");
 const { promises: fs } = require("fs");
+const { getOrCreateUser } = require("./lib/server/graphql");
 
 const requireEnv = (name) => {
   const value = process.env[name];
@@ -119,10 +120,22 @@ async function main() {
             allowHttpForRedirectUrl: dev,
             isB2C: true,
           },
-          (profile, done) => {
-            done(null, {
+          async (profile, done) => {
+            const response = await getOrCreateUser({
               authId: profile.sub,
               name: profile.displayName,
+            });
+            const {
+              getOrCreateUser: {
+                name,
+                authId,
+                is_platform_admin: isPlatformAdmin,
+              },
+            } = response;
+            done(null, {
+              authId,
+              name,
+              isPlatformAdmin,
               emails: profile.emails,
             });
           }

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -7,7 +7,7 @@ const passport = require("passport");
 const OIDCStrategy = require("passport-azure-ad").OIDCStrategy;
 const next = require("next");
 const dotenv = require("dotenv");
-const Noop = require("./noop-passport-strategy");
+const Noop = require("./lib/server/noop-passport-strategy");
 
 const url = require("url");
 const { promises: fs } = require("fs");
@@ -126,13 +126,13 @@ async function main() {
               name: profile.displayName,
             });
             const {
-              getOrCreateUser: {
-                name,
-                authId,
-                is_platform_admin: isPlatformAdmin,
-              },
-            } = response;
+              id,
+              name,
+              authId,
+              isPlatformAdmin,
+            } = response.getOrCreateUser;
             done(null, {
+              id,
               authId,
               name,
               isPlatformAdmin,

--- a/frontend/stubServer/resolver.js
+++ b/frontend/stubServer/resolver.js
@@ -4,6 +4,7 @@ const fileUploadUrlResponse = require("../cypress/fixtures/file-upload-url-graph
 const filesByFolderResponse = require("../cypress/fixtures/files-by-folder-graphql-response.json");
 const folderResponse = require("../cypress/fixtures/folder-graphql-response.json");
 const foldersByWorkspaceResponse = require("../cypress/fixtures/folders-by-workspace-graphql-response.json");
+const getOrCreateUserResponse = require("../cypress/fixtures/get-or-create-user-graphql-response.json");
 const workspaceResponse = require("../cypress/fixtures/workspace-graphql-response.json");
 
 const workspacesResolver = {
@@ -30,6 +31,10 @@ const folderMutation = {
   createFolder: async () => createFolderResponse.data.createFolder,
 };
 
+const userMutation = {
+  getOrCreateUser: async () => getOrCreateUserResponse.data.getOrCreateUser,
+};
+
 module.exports = (schema) => {
   const federationResolver = {
     _service: async () => ({
@@ -45,6 +50,6 @@ module.exports = (schema) => {
       ...fileUploadUrlResolver,
       ...federationResolver,
     },
-    Mutation: { ...folderMutation },
+    Mutation: { ...folderMutation, ...userMutation },
   };
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,5 +15,5 @@
     "jsx": "preserve"
   },
   "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "jest.setup.js"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "jest.setup.js", "lib/server/*.js"]
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2587,6 +2587,21 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/passport-strategy@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@types/passport-strategy/-/passport-strategy-0.2.35.tgz#e52f5212279ea73f02d9b06af67efe9cefce2d0c"
+  integrity sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==
+  dependencies:
+    "@types/express" "*"
+    "@types/passport" "*"
+
+"@types/passport@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.4.tgz#1b35c4e197560d3974fa5f71711b6e9cce0711f0"
+  integrity sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/pg-types@*":
   version "1.11.5"
   resolved "https://registry.yarnpkg.com/@types/pg-types/-/pg-types-1.11.5.tgz#1eebbe62b6772fcc75c18957a90f933d155e005b"


### PR DESCRIPTION
On login:

* take azure auth id and call getOrCreateUser mutation
* store more things in the User object in the frontend (we renamed .id to authId and added .id as the id of user in the workspace-service database)

We also refactored requireEnv so that it could be used in js land. We also hand-rolled our getOrCreateUser query using urql rather than generating it, because typescript :(.

Would be interesting to hear people's ideas about how to make requireEnv less terrible.

![](https://media.giphy.com/media/gui67fZ3xIneM/giphy.gif)