### PR TITLE
Align requireEnv() types with healthcheck

### DIFF
--- a/frontend/lib/server/requireEnv.js
+++ b/frontend/lib/server/requireEnv.js
@@ -1,7 +1,28 @@
 // @ts-check
 
+// Hack to make typescript keep the list of valid names in sync with our
+// healthcheck endpoint. If this was a typescript file, we would write:
+//
+//     const ENV_VAR_NAMES = [...] as const
+//
+// and type `name` as:
+//
+//     typeof ENV_VAR_NAMES[number]
+//
+// Unfortunately, `as const` is not valid javascript, and there isn't
+// a JSDoc equivalent, so we have to use an object, and type `name` as:
+//
+//     keyof typeof ENV_VAR_NAMES
+//
+const ENV_VAR_NAMES = {
+  EVENTGRID_TOPIC_ENDPOINT: 1,
+  EVENTGRID_TOPIC_KEY: 1,
+  PG_URL: 1,
+  WORKSPACE_SERVICE_GRAPHQL_ENDPOINT: 1,
+};
+
 /**
- * @param {string} name
+ * @param {keyof typeof ENV_VAR_NAMES} name
  * @returns {string}
  */
 const requireEnv = (name) => {
@@ -13,4 +34,4 @@ const requireEnv = (name) => {
   return value;
 };
 
-module.exports = { requireEnv };
+module.exports = { ENV_VAR_NAMES, requireEnv };

--- a/frontend/pages/api/health.ts
+++ b/frontend/pages/api/health.ts
@@ -1,14 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-const requiredEnvVars = [
-  "EVENTGRID_TOPIC_ENDPOINT",
-  "EVENTGRID_TOPIC_KEY",
-  "PG_URL",
-  "WORKSPACE_SERVICE_GRAPHQL_ENDPOINT",
-];
+import { ENV_VAR_NAMES } from "../../lib/server/requireEnv";
 
 export default (_: NextApiRequest, res: NextApiResponse) => {
-  const missingEnvVars = requiredEnvVars.filter((name) => !process.env[name]);
+  const missingEnvVars = Object.keys(ENV_VAR_NAMES).filter(
+    (name) => !process.env[name]
+  );
   if (missingEnvVars.length > 0) {
     res.status(500).json({
       status: "Error",


### PR DESCRIPTION
Only allow requireEnv(name) if name is covered by our
healthcheck endpoint. This should stop us from allowing
misconfigured servers into the load balancer.

Note that we don't use @ts-check in all of our js files,
so some things might slip through the gaps for now.


See https://github.com/FutureNHS/futurenhs-platform/pull/347#discussion_r503338143 for more background.