### PR TITLE
Setup script fixes

### DIFF
--- a/workspace-service/Makefile
+++ b/workspace-service/Makefile
@@ -68,6 +68,10 @@ migrate: ## Run migrations on current cluster
 prepare: migrate-local ## Prepares new version of sqlx-data.json
 	cargo clean --package workspace_service && DATABASE_URL=$(localdb) cargo sqlx prepare -- --bin workspace_service
 
+.PHONY: default-folders-local
+default-folders-local: ## make folders locally (requires you to be running `make run-local` in another tab).
+	./scripts/create-workspace-if-needed.sh local
+
 .PHONY: graphql-schema.json
 graphql-schema.json: 
 	cargo run -- --generate-schema-only >$@

--- a/workspace-service/migrations/20201014134400_create_admin_user.sql
+++ b/workspace-service/migrations/20201014134400_create_admin_user.sql
@@ -1,0 +1,9 @@
+INSERT into users (
+    auth_id,
+    name,
+    is_platform_admin
+) VALUES (
+    'feedface-0000-0000-0000-000000000000',
+    'Initial Admin User',
+    true
+);

--- a/workspace-service/scripts/create-default-test-folders.sh
+++ b/workspace-service/scripts/create-default-test-folders.sh
@@ -49,15 +49,21 @@ fi
 ./create-folder-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Good News"
 ./create-folder-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "NHS COVID-19 Data Store"
 
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Coronavirus Numbers.csv"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Trust List.doc"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Infographic.png"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Surgery.mov"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Leaflet.pdf"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Motivational Speech.ppt"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Encryption Keys.txt"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Backup.zip"
+# `make run-local` cannot upload files because it has no access to azure blob storage.
+# `make run` could theoretically upload files, but we're reaching the limit of how complex
+# I'm comfortable making my bash scripts. We should really make a proper migration script
+# in a proper language that does this properly.
+if false; then
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Coronavirus Numbers.csv"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Trust List.doc"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Infographic.png"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Surgery.mov"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Leaflet.pdf"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Motivational Speech.ppt"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Encryption Keys.txt"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Data" "Backup.zip"
 
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Evidence" "London Region NHS England Safeguarding Annual Review.ppt"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Evidence" "Midlands & East Region Safeguarding Annual Report.pdf"
-./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Evidence" "South East Region Safeguarding Annual Report.doc"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Evidence" "London Region NHS England Safeguarding Annual Review.ppt"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Evidence" "Midlands & East Region Safeguarding Annual Report.pdf"
+	./create-file-if-needed.sh "$ENVIRONMENT" "$WORKSPACE_TITLE" "Evidence" "South East Region Safeguarding Annual Report.doc"
+fi

--- a/workspace-service/scripts/create-file-if-needed.sh
+++ b/workspace-service/scripts/create-file-if-needed.sh
@@ -75,6 +75,7 @@ fi
 FILE_TYPE=$(echo $FILE_NAME | sed -e 's/^.*[.]//' -e s/png/img/)
 FILE_TITLE=$(echo $FILE_NAME | sed -e 's/[.][^.]*$//')
 
+# FIXME: This doesn't actually work. Let's rip this out and do this in a proper language.
 body=$(
 	jq \
 		--null-input \

--- a/workspace-service/scripts/create-workspace-if-needed.sh
+++ b/workspace-service/scripts/create-workspace-if-needed.sh
@@ -72,6 +72,7 @@ response=$(
 		--show-error \
 		-XPOST \
 		$WORKSPACE_SERVICE_GRAPHQL_ENDPOINT \
+		-H 'x-user-auth-id: feedface-0000-0000-0000-000000000000' \
 		-H 'Content-Type: application/json' \
 		-d "$body"
 )


### PR DESCRIPTION
[AB#1817](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1817)

## Acceptance Criteria

Now that create-workspace requires you to be admin:

* Make an admin user as part of the initial migrations (I think this is the best way to bootstrap the cluster)
* Make the create-folder requests using that admin user's auth_id.

## Also includes:

* create-file-if-needed.sh is broken, so we commented it out.

## Pre-review checklist:

- [x] Tests

## Test:

- [x] Tested locally


![](https://media.giphy.com/media/UhEiMiN3BqOZi/giphy-downsized.gif)