### PR TITLE
Lock down update_user() to be admin-only

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -57,6 +57,54 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
 
+### Permissions
+
+By default the system is installed with a single platform admin. This has auth_id="feedface-0000-0000-0000-000000000000" and is_platform_admin set to true. This is the user that `yarn dev` uses by default.
+
+All other users are created when you log in using azure, and are not platform admin.
+
+If you go to https://fnhs-dev-\$FNHSNAME.westeurope.cloudapp.azure.com/auth/login?next=/api/graphql and attempt to do something that requires auth, like this then you will get an error:
+
+```
+mutation {
+  updateUser(
+    updateUser: {
+      authId: "feedface-0000-0000-0000-000000000000"
+      isPlatformAdmin: true
+    }
+  ) {
+    isPlatformAdmin
+  }
+}
+```
+
+- To find your auth id, go to https://portal.azure.com/#blade/Microsoft_AAD_IAM/UsersManagementMenuBlade/AllUsers and select the user you log in with, of `User Type` 'Member'. On the Profile page you are taken to, copy the `Object ID`.
+
+- You can then go to http://workspace-service.workspace-service/graphiql and give yourself admin like this:
+
+In the query box, type:
+
+```
+mutation {
+  updateUser(
+    updateUser: {
+      authId: YOUR_OBJECT_ID
+      isPlatformAdmin: true
+    }
+  ) {
+    isPlatformAdmin
+  }
+}
+```
+
+- In the "HTTP HEADERS" box at the bottom, put:
+
+```
+{"x-user-auth-id": "feedface-0000-0000-0000-000000000000"}
+```
+
+- Submit the request.
+
 ## Testing
 
 ### Cypress

--- a/workspace-service/src/db.rs
+++ b/workspace-service/src/db.rs
@@ -334,7 +334,7 @@ impl User {
             id: Uuid::new_v4(),
             auth_id: auth_id.clone(),
             name: "Test".to_string(),
-            is_platform_admin: true,
+            is_platform_admin: auth_id.to_string() == "feedface-0000-0000-0000-000000000000",
         })
     }
 
@@ -343,7 +343,7 @@ impl User {
             id: Uuid::new_v4(),
             auth_id: auth_id.clone(),
             name: name.to_string(),
-            is_platform_admin: true,
+            is_platform_admin: auth_id.to_string() == "feedface-0000-0000-0000-000000000000",
         })
     }
 

--- a/workspace-service/src/graphql/mod.rs
+++ b/workspace-service/src/graphql/mod.rs
@@ -54,7 +54,7 @@ struct Mutation(
 );
 
 #[derive(Debug)]
-struct RequestingUser {
+pub struct RequestingUser {
     auth_id: Uuid,
 }
 

--- a/workspace-service/src/graphql/test_mocks.rs
+++ b/workspace-service/src/graphql/test_mocks.rs
@@ -3,6 +3,9 @@ use fnhs_event_models::EventClient;
 use sqlx::PgPool;
 use std::sync::mpsc::{sync_channel, Receiver};
 use std::sync::Arc;
+use uuid::Uuid;
+
+use super::RequestingUser;
 
 /// Should explode if you actually try to use it.
 pub async fn mock_connection_pool() -> anyhow::Result<PgPool> {
@@ -15,4 +18,16 @@ pub async fn mock_connection_pool() -> anyhow::Result<PgPool> {
 pub fn mock_event_emitter() -> (Receiver<Event>, EventClient) {
     let (sender, receiver) = sync_channel(1000);
     (receiver, EventClient::with_publisher(Arc::new(sender)))
+}
+
+pub fn mock_admin_requesting_user() -> RequestingUser {
+    RequestingUser {
+        auth_id: Uuid::parse_str("feedface-0000-0000-0000-000000000000").unwrap(),
+    }
+}
+
+pub fn mock_unprivileged_requesting_user() -> RequestingUser {
+    RequestingUser {
+        auth_id: Uuid::parse_str("deadbeef-0000-0000-0000-000000000000").unwrap(),
+    }
 }

--- a/workspace-service/src/graphql/users.rs
+++ b/workspace-service/src/graphql/users.rs
@@ -55,6 +55,7 @@ impl UsersMutation {
             .await?
             .into())
     }
+
     #[field(desc = "Update a user (returns the user)")]
     async fn update_user(
         &self,

--- a/workspace-service/src/graphql/users.rs
+++ b/workspace-service/src/graphql/users.rs
@@ -1,5 +1,6 @@
-use super::db;
+use super::{db, RequestingUser};
 use async_graphql::{Context, FieldResult, InputObject, Object, SimpleObject, ID};
+use sqlx::PgPool;
 use uuid::Uuid;
 
 #[SimpleObject(desc = "A user")]
@@ -64,21 +65,76 @@ impl UsersMutation {
     ) -> FieldResult<User> {
         let pool = context.data()?;
 
-        let requesting_user = context.data::<super::RequestingUser>()?;
-        let requesting_user = db::User::find_by_auth_id(&requesting_user.auth_id, pool).await?;
-        if !requesting_user.is_platform_admin {
-            return Err(anyhow::anyhow!(
-                "User with auth_id {} is not a platform admin.",
-                requesting_user.auth_id
-            )
-            .into());
-        }
+        let requesting_user = context.data::<RequestingUser>()?;
+        update_user_impl(pool, requesting_user, update_user).await
+    }
+}
 
-        let auth_id = Uuid::parse_str(&update_user.auth_id)?;
-        Ok(
-            db::User::update(&auth_id, update_user.is_platform_admin, pool)
-                .await?
-                .into(),
+async fn update_user_impl(
+    pool: &PgPool,
+    requesting_user: &RequestingUser,
+    update_user: UpdateUser,
+) -> FieldResult<User> {
+    let requesting_user = db::User::find_by_auth_id(&requesting_user.auth_id, pool).await?;
+    if !requesting_user.is_platform_admin {
+        return Err(anyhow::anyhow!(
+            "User with auth_id {} is not a platform admin.",
+            requesting_user.auth_id
         )
+        .into());
+    }
+
+    let auth_id = Uuid::parse_str(&update_user.auth_id)?;
+    Ok(
+        db::User::update(&auth_id, update_user.is_platform_admin, pool)
+            .await?
+            .into(),
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::graphql::test_mocks::*;
+
+    #[async_std::test]
+    async fn update_user_succeds_if_admin() -> anyhow::Result<()> {
+        let pool = mock_connection_pool().await?;
+        update_user_impl(
+            &pool,
+            &mock_admin_requesting_user(),
+            UpdateUser {
+                auth_id: Uuid::new_v4().into(),
+                is_platform_admin: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn update_user_fails_if_not_admin() -> anyhow::Result<()> {
+        let pool = mock_connection_pool().await?;
+
+        let user = mock_unprivileged_requesting_user();
+
+        let result = update_user_impl(
+            &pool,
+            &user,
+            UpdateUser {
+                auth_id: user.auth_id.into(),
+                is_platform_admin: true,
+            },
+        )
+        .await;
+
+        assert_eq!(
+            result.err().unwrap().0,
+            "User with auth_id deadbeef-0000-0000-0000-000000000000 is not a platform admin."
+        );
+
+        Ok(())
     }
 }

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -128,7 +128,7 @@ async fn create_workspace(
     let user = db::User::find_by_auth_id(&requesting_user.auth_id, pool).await?;
     if !user.is_platform_admin {
         return Err(anyhow::anyhow!(
-            "User with auth_id {} is not a platform admin. No workspace for you.",
+            "User with auth_id {} does not have permission to create a workspace.",
             requesting_user.auth_id,
         )
         .into());
@@ -198,7 +198,7 @@ mod test {
         )
         .await;
 
-        assert_eq!(result.err().unwrap().0, "User with auth_id deadbeef-0000-0000-0000-000000000000 is not a platform admin. No workspace for you.");
+        assert_eq!(result.err().unwrap().0, "User with auth_id deadbeef-0000-0000-0000-000000000000 does not have permission to create a workspace.");
 
         assert_eq!(events.try_iter().collect::<Vec<_>>().len(), 0);
 


### PR DESCRIPTION
[AB#1817](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1817)


## Acceptance Criteria

* It should not be possible for a user to upgrade themselves to admin if they are not already admin

## Pre-review checklist:

- [x] Tests

## Testing information

- Is there any special setup required?

- Test plan?

* The test user that `yarn dev` uses should already be an admin (auth_id = feedface-0000-0000-0000-000000000000).
* Your user on your cluster will default to not being admin (I made everyone's users admin on prod though).
* you can set headers in http://workspace-service.workspace-service/graphiql

therefore:

* go to https://fnhs-dev-david.westeurope.cloudapp.azure.com/auth/login?next=/api/graphql and try to 
```
mutation {
  updateUser(updateUser: {authId: "feedface-0000-0000-0000-000000000000", isPlatformAdmin: true}) {isPlatformAdmin}
}
```
should respond something like:
```
{
  "errors": [
    {
      "message": "User with auth_id 9ba8c965-7879-4f17-8af2-072b3a310626 is not a platform admin.",
      "path": [
        "updateUser"
      ],
      "extensions": {
        "code": "DOWNSTREAM_SERVICE_ERROR",
        "serviceName": "workspace-service",
        "query": "mutation{updateUser(updateUser:{authId:\"feedface-0000-0000-0000-000000000000\" isPlatformAdmin:true}){isPlatformAdmin}}",
        "variables": {}
      }
    }
  ],
  "data": null
}
```

* kubefwd
* follow instructions in frontend/README.md

## Test:

- [x] Tested locally
