### PR TITLE
Invalidate workspace service cache

### DIFF
--- a/.github/workflows/workspace-service-branch.yaml
+++ b/.github/workflows/workspace-service-branch.yaml
@@ -59,7 +59,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             futurenhs-platform/workspace-service/target
-          key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}-a_
+          key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}-1
       - name: Build
         working-directory: futurenhs-platform/workspace-service
         run: |

--- a/.github/workflows/workspace-service-master.yaml
+++ b/.github/workflows/workspace-service-master.yaml
@@ -60,7 +60,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             futurenhs-platform/workspace-service/target
-          key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}-a
+          key: cargo-${{ hashFiles('futurenhs-platform/workspace-service/Cargo.lock') }}-1
       - name: Build
         working-directory: futurenhs-platform/workspace-service
         run: |


### PR DESCRIPTION
sqlx prepare seems to have some cache issues. Sometimes it just won't
produce the correct result and the only way to fix it is to clear the
cache.

This may have been fixed in the latest master branch of sqlx. We should
try to update.