### PR TITLE
Change files table to make use of file versions

### DIFF
--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -191,6 +191,22 @@
           {
             "args": [],
             "deprecationReason": null,
+            "description": "ID of the latest version of the file",
+            "isDeprecated": false,
+            "name": "latestVersion",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
             "description": "The time the file was created",
             "isDeprecated": false,
             "name": "createdAt",

--- a/workspace-service/migrations/20201021141602_alter_files.sql
+++ b/workspace-service/migrations/20201021141602_alter_files.sql
@@ -1,0 +1,63 @@
+ALTER TABLE files
+ADD COLUMN deleted_by uuid REFERENCES users,
+ADD COLUMN created_by uuid REFERENCES users,
+ADD COLUMN latest_version uuid REFERENCES file_versions
+;
+
+INSERT INTO file_versions
+(
+    folder,
+    file,
+    file_title,
+    file_description,
+    file_name,
+    file_type,
+    blob_storage_path,
+    created_at,
+    created_by,
+    version_number,
+    version_label
+)
+SELECT
+    folder,
+    id,
+    title,
+    description,
+    file_name,
+    file_type,
+    blob_storage_path,
+    created_at,
+    (SELECT id FROM users WHERE auth_id = 'feedface-0000-0000-0000-000000000000'),
+    1,
+    ''
+FROM
+    files;
+
+UPDATE files
+SET deleted_by = (SELECT id FROM users WHERE auth_id = 'feedface-0000-0000-0000-000000000000')
+    WHERE deleted_at IS NOT NULL;
+
+UPDATE files
+SET created_by = (SELECT id FROM users WHERE auth_id = 'feedface-0000-0000-0000-000000000000');
+
+UPDATE files
+SET latest_version = (
+    SELECT id
+    FROM file_versions
+    WHERE file = files.id
+);
+
+ALTER TABLE files
+    ALTER COLUMN created_by SET NOT NULL,
+    ALTER COLUMN latest_version SET NOT NULL
+;
+
+ALTER TABLE files
+    DROP COLUMN title,
+    DROP COLUMN description,
+    DROP COLUMN folder,
+    DROP COLUMN file_name,
+    DROP COLUMN file_type,
+    DROP COLUMN blob_storage_path,
+    DROP COLUMN modified_at
+;

--- a/workspace-service/migrations/20201021141602_alter_files.sql
+++ b/workspace-service/migrations/20201021141602_alter_files.sql
@@ -1,7 +1,7 @@
 ALTER TABLE files
 ADD COLUMN deleted_by uuid REFERENCES users,
 ADD COLUMN created_by uuid REFERENCES users,
-ADD COLUMN latest_version uuid REFERENCES file_versions
+ADD COLUMN latest_version uuid REFERENCES file_versions DEFERRABLE
 ;
 
 INSERT INTO file_versions

--- a/workspace-service/migrations/20201022112201_file-indexes.sql
+++ b/workspace-service/migrations/20201022112201_file-indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX folder_idx ON file_versions (folder);
+CREATE INDEX file_idx ON file_versions (file);

--- a/workspace-service/sql/file_versions/create.sql
+++ b/workspace-service/sql/file_versions/create.sql
@@ -13,3 +13,4 @@ INSERT INTO file_versions (
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10)
 RETURNING *
+

--- a/workspace-service/sql/file_versions/create.sql
+++ b/workspace-service/sql/file_versions/create.sql
@@ -1,4 +1,5 @@
 INSERT INTO file_versions (
+    id,
     folder,
     file,
     file_title,
@@ -11,6 +12,5 @@ INSERT INTO file_versions (
     version_number,
     version_label
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), $9, $10, $11)
 RETURNING *
-

--- a/workspace-service/sql/files/create.sql
+++ b/workspace-service/sql/files/create.sql
@@ -1,3 +1,3 @@
-INSERT INTO files (title, description, folder, file_name, file_type, blob_storage_path, created_at, modified_at, deleted_at)
-VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), NULL) 
+INSERT INTO files (created_by, created_at, latest_version)
+VALUES ($1, NOW(), $2) 
 RETURNING *

--- a/workspace-service/sql/files/delete.sql
+++ b/workspace-service/sql/files/delete.sql
@@ -1,4 +1,17 @@
 UPDATE files
-SET deleted_at = NOW()
-WHERE id = $1
-RETURNING *
+SET deleted_at = NOW(), deleted_by = $2
+FROM file_versions
+WHERE files.id = $1
+AND files.latest_version = file_versions.id
+RETURNING
+    files.id,
+    file_versions.file_title AS title,
+    file_versions.file_description AS description,
+    file_versions.folder,
+    file_versions.file_name,
+    file_versions.blob_storage_path,
+    file_versions.file_type,
+    files.created_at,
+    file_versions.created_at AS modified_at,
+    files.deleted_at,
+    files.latest_version

--- a/workspace-service/sql/files/find_by_folder.sql
+++ b/workspace-service/sql/files/find_by_folder.sql
@@ -1,15 +1,16 @@
-SELECT id,
-    title,
-    description,
-    folder,
-    file_name,
-    file_type,
-    blob_storage_path,
-    created_at,
-    modified_at,
-    deleted_at
+SELECT files.id,
+    file_versions.file_title AS title,
+    file_versions.file_description AS description,
+    file_versions.folder,
+    file_versions.file_name,
+    file_versions.blob_storage_path,
+    file_versions.file_type,
+    files.created_at,
+    file_versions.created_at AS modified_at,
+    files.deleted_at,
+    files.latest_version
 
-FROM files
-WHERE folder = $1
-AND deleted_at IS NULL
-ORDER BY title
+FROM files JOIN file_versions ON files.latest_version = file_versions.id
+WHERE file_versions.folder = $1
+AND files.deleted_at IS NULL
+ORDER BY file_versions.file_title

--- a/workspace-service/sql/files/find_by_id.sql
+++ b/workspace-service/sql/files/find_by_id.sql
@@ -1,14 +1,15 @@
-SELECT id,
-    title,
-    description,
-    folder,
-    file_name,
-    file_type,
-    blob_storage_path,
-    created_at,
-    modified_at,
-    deleted_at
-FROM files
-WHERE id = $1
-AND deleted_at IS NULL
+SELECT files.id,
+    file_versions.file_title AS title,
+    file_versions.file_description AS description,
+    file_versions.folder,
+    file_versions.file_name,
+    file_versions.blob_storage_path,
+    file_versions.file_type,
+    files.created_at,
+    file_versions.created_at AS modified_at,
+    files.deleted_at,
+    files.latest_version
 
+FROM files JOIN file_versions ON files.latest_version = file_versions.id
+WHERE files.id = $1
+AND files.deleted_at IS NULL

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -1,5 +1,85 @@
 {
   "db": "PostgreSQL",
+  "1088816e7a307f67fb0a1d0d7a819ae51170c31dd50b31f16208e4b7d3d04fd8": {
+    "query": "SELECT files.id,\n    file_versions.file_title AS title,\n    file_versions.file_description AS description,\n    file_versions.folder,\n    file_versions.file_name,\n    file_versions.blob_storage_path,\n    file_versions.file_type,\n    files.created_at,\n    file_versions.created_at AS modified_at,\n    files.deleted_at,\n    files.latest_version\n\nFROM files JOIN file_versions ON files.latest_version = file_versions.id\nWHERE files.id = $1\nAND files.deleted_at IS NULL\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "folder",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "file_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "blob_storage_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "file_type",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 8,
+          "name": "modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 9,
+          "name": "deleted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 10,
+          "name": "latest_version",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false
+      ]
+    }
+  },
   "1428409bb70e6a2ff2c1210b46400ab6ad05fdd8fa7a50c72c7f1c04214167a9": {
     "query": "SELECT id, \n    title,\n    description,\n    workspace\nFROM folders\nWHERE id = $1\n",
     "describe": {
@@ -69,175 +149,6 @@
         ]
       },
       "nullable": [
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "2a8c5a976426f64dd6925adf663d51017c2f1c617e238bbe86060d3a2db7e235": {
-    "query": "UPDATE files\nSET deleted_at = NOW()\nWHERE id = $1\nRETURNING *\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "title",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "folder",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "file_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "file_type",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "blob_storage_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "modified_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 9,
-          "name": "deleted_at",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true
-      ]
-    }
-  },
-  "33aa670d2117ff8b6d9e6b327f2d0f64d8e9cdfd1ef037bb5abd9c4237f8837c": {
-    "query": "INSERT INTO file_versions (\n    folder,\n    file,\n    file_title,\n    file_description,\n    file_name,\n    file_type,\n    blob_storage_path,\n    created_at,\n    created_by,\n    version_number,\n    version_label\n)\nVALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8, $9, $10)\nRETURNING *\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "folder",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "file",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 3,
-          "name": "file_title",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "file_description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "file_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "file_type",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "blob_storage_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 8,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 9,
-          "name": "created_by",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 10,
-          "name": "version_number",
-          "type_info": "Int2"
-        },
-        {
-          "ordinal": 11,
-          "name": "version_label",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Uuid",
-          "Int2",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
         false,
         false,
         false,
@@ -394,6 +305,102 @@
       ]
     }
   },
+  "6838012c47967c14881d876ed76d001c68b4f95ae423f35ebc3c49adcaf2b3da": {
+    "query": "INSERT INTO file_versions (\n    id,\n    folder,\n    file,\n    file_title,\n    file_description,\n    file_name,\n    file_type,\n    blob_storage_path,\n    created_at,\n    created_by,\n    version_number,\n    version_label\n)\nVALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), $9, $10, $11)\nRETURNING *\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "folder",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "file",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 3,
+          "name": "file_title",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "file_description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "file_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "file_type",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "blob_storage_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 8,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 9,
+          "name": "created_by",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 10,
+          "name": "version_number",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 11,
+          "name": "version_label",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Uuid",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Uuid",
+          "Int2",
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "7e36b4f75277160f17428493ede8939d337eed375864a238af996d4957649f4d": {
     "query": "DELETE FROM workspaces\nWHERE id = $1\nRETURNING id, title, description\n",
     "describe": {
@@ -426,154 +433,6 @@
       ]
     }
   },
-  "8149b23a32d762e80bc72474f46f29ba1bf45ba7bc8b23777c0746c37c71ad8f": {
-    "query": "SELECT id,\n    title,\n    description,\n    folder,\n    file_name,\n    file_type,\n    blob_storage_path,\n    created_at,\n    modified_at,\n    deleted_at\nFROM files\nWHERE id = $1\nAND deleted_at IS NULL\n\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "title",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "folder",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "file_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "file_type",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "blob_storage_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "modified_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 9,
-          "name": "deleted_at",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true
-      ]
-    }
-  },
-  "855c163a92098bd38f165e14432f1c043583019de61b732ce62aa241e66f4ef2": {
-    "query": "SELECT id,\n    title,\n    description,\n    folder,\n    file_name,\n    file_type,\n    blob_storage_path,\n    created_at,\n    modified_at,\n    deleted_at\n\nFROM files\nWHERE folder = $1\nAND deleted_at IS NULL\nORDER BY title\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "title",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "folder",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "file_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "file_type",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "blob_storage_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "modified_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 9,
-          "name": "deleted_at",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true
-      ]
-    }
-  },
   "8966dfe9e28e5225f73a5258085484b942503d3db9baae72e9d17379eb9be9a3": {
     "query": "SELECT id,\n    title,\n    description\nFROM workspaces\nORDER BY id\n",
     "describe": {
@@ -599,6 +458,57 @@
       },
       "nullable": [
         false,
+        false,
+        false
+      ]
+    }
+  },
+  "b3973f7ae3ca5e3e1e5b6c0767f18eb3b4885faea01905855d3663781420ad8b": {
+    "query": "INSERT INTO files (created_by, created_at, latest_version)\nVALUES ($1, NOW(), $2) \nRETURNING *\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "deleted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 3,
+          "name": "deleted_by",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "created_by",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 5,
+          "name": "latest_version",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
         false,
         false
       ]
@@ -677,85 +587,6 @@
       ]
     }
   },
-  "d47447a56505c02b03dab9bc16d3dd9bff16dc2110c43c49d5f78770c1661872": {
-    "query": "INSERT INTO files (title, description, folder, file_name, file_type, blob_storage_path, created_at, modified_at, deleted_at)\nVALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), NULL) \nRETURNING *\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "title",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "description",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "folder",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 4,
-          "name": "file_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "file_type",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "blob_storage_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 8,
-          "name": "modified_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 9,
-          "name": "deleted_at",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Uuid",
-          "Text",
-          "Text",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true
-      ]
-    }
-  },
   "d5d3145051893e2cf7ceb9bffbc9934d37d7c3ecc2c0c4addcf4f970cfd0c209": {
     "query": "INSERT INTO folders (title, description, workspace)\nVALUES ($1, $2, $3)\nRETURNING id, title, description, workspace\n",
     "describe": {
@@ -828,6 +659,87 @@
       ]
     }
   },
+  "ef2e726e306ddabb2b8ab90d1357ac5899cc98efbbf7e8f65a7155d3f75dbfbf": {
+    "query": "UPDATE files\nSET deleted_at = NOW(), deleted_by = $2\nFROM file_versions\nWHERE files.id = $1\nAND files.latest_version = file_versions.id\nRETURNING\n    files.id,\n    file_versions.file_title AS title,\n    file_versions.file_description AS description,\n    file_versions.folder,\n    file_versions.file_name,\n    file_versions.blob_storage_path,\n    file_versions.file_type,\n    files.created_at,\n    file_versions.created_at AS modified_at,\n    files.deleted_at,\n    files.latest_version\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "folder",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "file_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "blob_storage_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "file_type",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 8,
+          "name": "modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 9,
+          "name": "deleted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 10,
+          "name": "latest_version",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false
+      ]
+    }
+  },
   "fab511bd36333130a3994817dd646ad8f2ebeff05f66eadd663741cff69440a9": {
     "query": "UPDATE users\nSET is_platform_admin = $2\nWHERE auth_id = $1\nRETURNING *\n",
     "describe": {
@@ -863,6 +775,86 @@
         false,
         false,
         false,
+        false
+      ]
+    }
+  },
+  "fd8fdd7353f67882eb09ac7bc71a7639b734f3d54d639b97d8d55544331734d4": {
+    "query": "SELECT files.id,\n    file_versions.file_title AS title,\n    file_versions.file_description AS description,\n    file_versions.folder,\n    file_versions.file_name,\n    file_versions.blob_storage_path,\n    file_versions.file_type,\n    files.created_at,\n    file_versions.created_at AS modified_at,\n    files.deleted_at,\n    files.latest_version\n\nFROM files JOIN file_versions ON files.latest_version = file_versions.id\nWHERE file_versions.folder = $1\nAND files.deleted_at IS NULL\nORDER BY file_versions.file_title\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "description",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "folder",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 4,
+          "name": "file_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "blob_storage_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "file_type",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 8,
+          "name": "modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 9,
+          "name": "deleted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 10,
+          "name": "latest_version",
+          "type_info": "Uuid"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
         false
       ]
     }

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -514,6 +514,16 @@
       ]
     }
   },
+  "b80c3e5c6e1620ccee068d08214bc0c787967400a6a10f45c6065ba22bea4369": {
+    "query": "SET CONSTRAINTS ALL DEFERRED;",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
   "bc9295f39b14cbd41e34a3633acb31d0d727753dc9803cb7fb7325fb2665b267": {
     "query": "INSERT INTO workspaces (title, description)\nVALUES ($1, $2)\nRETURNING id, title, description\n",
     "describe": {

--- a/workspace-service/src/db/file_versions.rs
+++ b/workspace-service/src/db/file_versions.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{types::Uuid, PgPool};
+use sqlx::{types::Uuid, Executor, Postgres};
 
 #[derive(Clone)]
 pub struct FileVersion {
@@ -23,7 +23,7 @@ pub struct FileVersion {
 
 impl FileVersion {
     #[allow(clippy::too_many_arguments)]
-    pub async fn create(
+    pub async fn create<'c, E>(
         id: Uuid,
         folder: Uuid,
         file: Uuid,
@@ -35,8 +35,11 @@ impl FileVersion {
         created_by: Uuid,
         version_number: i16,
         version_label: &str,
-        pool: &PgPool,
-    ) -> Result<FileVersion> {
+        executor: E,
+    ) -> Result<FileVersion>
+    where
+        E: Executor<'c, Database = Postgres>,
+    {
         let file_version = sqlx::query_file_as!(
             FileVersion,
             "sql/file_versions/create.sql",
@@ -52,7 +55,7 @@ impl FileVersion {
             version_number,
             version_label,
         )
-        .fetch_one(pool)
+        .fetch_one(executor)
         .await?;
 
         Ok(file_version)

--- a/workspace-service/src/db/file_versions.rs
+++ b/workspace-service/src/db/file_versions.rs
@@ -24,15 +24,15 @@ pub struct FileVersion {
 impl FileVersion {
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
-        id: &Uuid,
-        folder: &Uuid,
-        file: &Uuid,
+        id: Uuid,
+        folder: Uuid,
+        file: Uuid,
         file_title: &str,
         file_description: &str,
         file_name: &str,
         file_type: &str,
         blob_storage_path: &str,
-        created_by: &Uuid,
+        created_by: Uuid,
         version_number: i16,
         version_label: &str,
         pool: &PgPool,

--- a/workspace-service/src/db/file_versions.rs
+++ b/workspace-service/src/db/file_versions.rs
@@ -24,6 +24,7 @@ pub struct FileVersion {
 impl FileVersion {
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
+        id: &Uuid,
         folder: &Uuid,
         file: &Uuid,
         file_title: &str,
@@ -32,13 +33,14 @@ impl FileVersion {
         file_type: &str,
         blob_storage_path: &str,
         created_by: &Uuid,
-        version_number: &i16,
+        version_number: i16,
         version_label: &str,
         pool: &PgPool,
     ) -> Result<FileVersion> {
         let file_version = sqlx::query_file_as!(
             FileVersion,
             "sql/file_versions/create.sql",
+            id,
             folder,
             file,
             file_title,

--- a/workspace-service/src/db/files.rs
+++ b/workspace-service/src/db/files.rs
@@ -12,45 +12,51 @@ pub struct File {
     pub created_by: Uuid,
     pub deleted_at: Option<DateTime<Utc>>,
     pub deleted_by: Option<Uuid>,
-    pub latest_version: Uuid
+    pub latest_version: Uuid,
+}
+
+#[derive(Clone)]
+pub struct FileWithVersion {
+    pub id: Uuid,
+    pub title: String,
+    pub blob_storage_path: String,
+    pub description: String,
+    pub folder: Uuid,
+    pub file_name: String,
+    pub file_type: String,
+    pub created_at: DateTime<Utc>,
+    pub modified_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+    pub latest_version: Uuid,
 }
 
 impl File {
-    pub async fn create(
-        created_by: &Uuid,
-        latest_version: &Uuid,
-        pool: &PgPool,
-    ) -> Result<File> {
-        let file = sqlx::query_file_as!(
-            File,
-            "sql/files/create.sql",
-            created_by,
-            latest_version
-        )
-        .fetch_one(pool)
-        .await?;
-
-        Ok(file)
-    }
-
-    pub async fn find_by_folder(folder: Uuid, pool: &PgPool) -> Result<Vec<File>> {
-        let files = sqlx::query_file_as!(File, "sql/files/find_by_folder.sql", folder)
-            .fetch_all(pool)
-            .await?;
-
-        Ok(files)
-    }
-
-    pub async fn find_by_id(id: Uuid, pool: &PgPool) -> Result<File> {
-        let file = sqlx::query_file_as!(File, "sql/files/find_by_id.sql", id)
+    pub async fn create(created_by: &Uuid, latest_version: &Uuid, pool: &PgPool) -> Result<File> {
+        let file = sqlx::query_file_as!(File, "sql/files/create.sql", created_by, latest_version)
             .fetch_one(pool)
             .await?;
 
         Ok(file)
     }
 
-    pub async fn delete(id: Uuid, pool: &PgPool) -> Result<File> {
-        let file = sqlx::query_file_as!(File, "sql/files/delete.sql", id)
+    pub async fn find_by_folder(folder: Uuid, pool: &PgPool) -> Result<Vec<FileWithVersion>> {
+        let files = sqlx::query_file_as!(FileWithVersion, "sql/files/find_by_folder.sql", folder)
+            .fetch_all(pool)
+            .await?;
+
+        Ok(files)
+    }
+
+    pub async fn find_by_id(id: Uuid, pool: &PgPool) -> Result<FileWithVersion> {
+        let file = sqlx::query_file_as!(FileWithVersion, "sql/files/find_by_id.sql", id)
+            .fetch_one(pool)
+            .await?;
+
+        Ok(file)
+    }
+
+    pub async fn delete(id: Uuid, deleted_by: Uuid, pool: &PgPool) -> Result<FileWithVersion> {
+        let file = sqlx::query_file_as!(FileWithVersion, "sql/files/delete.sql", id, deleted_by)
             .fetch_one(pool)
             .await?;
 

--- a/workspace-service/src/db/files.rs
+++ b/workspace-service/src/db/files.rs
@@ -31,7 +31,7 @@ pub struct FileWithVersion {
 }
 
 impl File {
-    pub async fn create(created_by: &Uuid, latest_version: &Uuid, pool: &PgPool) -> Result<File> {
+    pub async fn create(created_by: Uuid, latest_version: Uuid, pool: &PgPool) -> Result<File> {
         let file = sqlx::query_file_as!(File, "sql/files/create.sql", created_by, latest_version)
             .fetch_one(pool)
             .await?;

--- a/workspace-service/src/db/files.rs
+++ b/workspace-service/src/db/files.rs
@@ -8,36 +8,24 @@ use sqlx::{types::Uuid, PgPool};
 #[derive(Clone)]
 pub struct File {
     pub id: Uuid,
-    pub title: String,
-    pub description: String,
-    pub folder: Uuid,
-    pub file_name: String,
-    pub file_type: String,
-    pub blob_storage_path: String,
     pub created_at: DateTime<Utc>,
-    pub modified_at: DateTime<Utc>,
+    pub created_by: Uuid,
     pub deleted_at: Option<DateTime<Utc>>,
+    pub deleted_by: Option<Uuid>,
+    pub latest_version: Uuid
 }
 
 impl File {
     pub async fn create(
-        title: &str,
-        description: &str,
-        folder: &Uuid,
-        file_name: &str,
-        file_type: &str,
-        blob_storage_path: &str,
+        created_by: &Uuid,
+        latest_version: &Uuid,
         pool: &PgPool,
     ) -> Result<File> {
         let file = sqlx::query_file_as!(
             File,
             "sql/files/create.sql",
-            title,
-            description,
-            folder,
-            file_name,
-            file_type,
-            blob_storage_path,
+            created_by,
+            latest_version
         )
         .fetch_one(pool)
         .await?;

--- a/workspace-service/src/db/files.rs
+++ b/workspace-service/src/db/files.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{types::Uuid, PgPool};
+use sqlx::{types::Uuid, Executor, PgPool, Postgres};
 
 #[derive(Clone)]
 pub struct File {
@@ -31,9 +31,12 @@ pub struct FileWithVersion {
 }
 
 impl File {
-    pub async fn create(created_by: Uuid, latest_version: Uuid, pool: &PgPool) -> Result<File> {
+    pub async fn create<'c, E>(created_by: Uuid, latest_version: Uuid, executor: E) -> Result<File>
+    where
+        E: Executor<'c, Database = Postgres>,
+    {
         let file = sqlx::query_file_as!(File, "sql/files/create.sql", created_by, latest_version)
-            .fetch_one(pool)
+            .fetch_one(executor)
             .await?;
 
         Ok(file)

--- a/workspace-service/src/db/mod.rs
+++ b/workspace-service/src/db/mod.rs
@@ -1,10 +1,23 @@
-mod files;
-pub use files::*;
 mod file_versions;
-pub use file_versions::*;
-mod workspaces;
-pub use workspaces::*;
+mod files;
 mod folders;
-pub use folders::*;
 mod users;
+mod workspaces;
+
+use anyhow::Result;
+pub use file_versions::*;
+pub use files::*;
+pub use folders::*;
+use sqlx::{Executor, Postgres};
 pub use users::*;
+pub use workspaces::*;
+
+pub async fn defer_all_constraints<'c, E>(executor: E) -> Result<()>
+where
+    E: Executor<'c, Database = Postgres>,
+{
+    sqlx::query!("SET CONSTRAINTS ALL DEFERRED;")
+        .execute(executor)
+        .await?;
+    Ok(())
+}

--- a/workspace-service/src/graphql/file_versions.rs
+++ b/workspace-service/src/graphql/file_versions.rs
@@ -91,6 +91,7 @@ impl FileVersionsMutation {
         // TODO: add event.
 
         let file_version = db::FileVersion::create(
+            &Uuid::new_v4(),
             &folder,
             &new_file_version.file,
             &new_file_version.file_title,
@@ -99,7 +100,7 @@ impl FileVersionsMutation {
             &new_file_version.file_type,
             &destination,
             &user.id,
-            &new_file_version.version_number,
+            new_file_version.version_number,
             &new_file_version.version_label,
             pool,
         )

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -51,6 +51,8 @@ pub struct File {
     pub file_name: String,
     /// The type of the file
     pub file_type: String,
+    /// ID of the latest version of the file
+    pub latest_version: ID,
     /// The time the file was created
     pub created_at: DateTime<Utc>,
     /// The time the file was modified
@@ -113,6 +115,7 @@ impl From<db::FileWithVersion> for File {
             folder: d.folder.into(),
             file_name: d.file_name,
             file_type: d.file_type,
+            latest_version: d.latest_version.into(),
             created_at: d.created_at,
             modified_at: d.modified_at,
             deleted_at: d.deleted_at,
@@ -200,6 +203,7 @@ impl FilesMutation {
             folder: file_version.folder.into(),
             file_name: file_version.file_name,
             file_type: file_version.file_type,
+            latest_version: file_version.id.into(),
             created_at: file.created_at,
             modified_at: file_version.created_at,
             deleted_at: file.deleted_at,

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -178,6 +178,7 @@ impl FilesMutation {
 
         let mut tx = pool.begin().await?;
         let version_id = Uuid::new_v4();
+        db::defer_all_constraints(&mut tx).await?;
         let file = db::File::create(user.id, version_id, &mut tx).await?;
         let file_version = db::FileVersion::create(
             version_id,

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -173,8 +173,9 @@ impl FilesMutation {
 
         // TODO: add event.
 
+        let mut tx = pool.begin().await?;
         let version_id = Uuid::new_v4();
-        let file = db::File::create(user.id, version_id, pool).await?;
+        let file = db::File::create(user.id, version_id, &mut tx).await?;
         let file_version = db::FileVersion::create(
             version_id,
             folder,
@@ -187,9 +188,10 @@ impl FilesMutation {
             user.id,
             1,
             "",
-            pool,
+            &mut tx,
         )
         .await?;
+        tx.commit().await?;
 
         Ok(File {
             id: file.id.into(),


### PR DESCRIPTION
[AB#1798](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1798)

## Acceptance Criteria

- File table references file versions table
- All file related GraphQL functions use the new file versions table
- No breaking changes of the GraphQL API

## Pre-review checklist:

- [ ] Tests

## Testing information

We should upload a new file and make sure it:
- Still works
- Shows up in the file list in the folder
- The file page works
- The file download works

## Test:

- [x] Tested locally