### PR TITLE
Better errors

### DIFF
--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -193,34 +193,50 @@ mod test {
     use super::*;
     use test_case::test_case;
 
-    #[test_case("filename.doc", Some("application/msword"), "no errors"
+    #[test_case("filename.doc", Some("application/msword")
+        , None
         ; "good extension doc")]
-    #[test_case("filename.docx", Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"), "no errors"
+    #[test_case("filename.docx", Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+        , None
         ; "good extension docx")]
-    #[test_case("image.png", Some("image/png"), "no errors"
+    #[test_case("image.png", Some("image/png")
+        , None
         ; "good mime type")]
-    #[test_case("image.png", Some("image/gif"), "the file extension is not valid for the specified MIME type"
+    #[test_case("image.png", Some("image/gif")
+        , Some("the file extension is not valid for the specified MIME type")
         ; "bad mime type")]
-    #[test_case("filename.zip", None, "the file name does not have an allowed extension"
+    #[test_case("filename.zip", None
+        , Some("the file name does not have an allowed extension")
         ; "bad extension zip")]
-    #[test_case("filename.txt", Some("text/plain"), "no errors"
+    #[test_case("filename.txt", Some("text/plain")
+        , None
         ; "good extension has dot")]
-    #[test_case("filenametxt", None, "the file name does not have an allowed extension"
+    #[test_case("filenametxt", None
+        , Some("the file name does not have an allowed extension")
         ; "bad extension no dot")]
-    #[test_case(".doc", None, "the file name must be between 5 and 255 characters long"
+    #[test_case(".doc", None
+        , Some("the file name must be between 5 and 255 characters long")
         ; "too short")]
-    #[test_case("%.doc", None, "the file name contains characters that are not alphanumeric, space, period, hyphen or underscore"
+    #[test_case("%.doc", None
+        , Some("the file name contains characters that are not alphanumeric, space, period, hyphen or underscore")
         ; "bad char percent")]
-    #[test_case("%", None, "\
-        the file name must be between 5 and 255 characters long, \
-        the file name contains characters that are not alphanumeric, space, period, hyphen or underscore, \
-        the file name does not have an allowed extension"
+    #[test_case("%", None
+        , Some("\
+            the file name must be between 5 and 255 characters long, \
+            the file name contains characters that are not alphanumeric, space, period, hyphen or underscore, \
+            the file name does not have an allowed extension")
         ; "multiple errors")]
-    #[test_case("🦀.doc", None, "the file name contains characters that are not alphanumeric, space, period, hyphen or underscore"
+    #[test_case("🦀.doc", None
+        , Some("the file name contains characters that are not alphanumeric, space, period, hyphen or underscore")
         ; "bad char emoji")]
-    #[test_case("xx\u{0}.doc", None, "the file name contains characters that are not alphanumeric, space, period, hyphen or underscore"
+    #[test_case("xx\u{0}.doc", None
+        , Some("the file name contains characters that are not alphanumeric, space, period, hyphen or underscore")
         ; "null char")]
-    fn validate_filename(file_name: &str, file_type: Option<&str>, expected: &str) {
+    fn validate_filename<'a>(
+        file_name: &'a str,
+        file_type: Option<&'a str>,
+        expected: Option<&'a str>,
+    ) {
         let new_file = NewFile {
             title: "".to_string(),
             description: "".to_string(),
@@ -229,15 +245,11 @@ mod test {
             file_type: file_type.unwrap_or("").to_string(),
             temporary_blob_storage_path: "".to_string(),
         };
-        if let Some(actual) = new_file
+        let actual = new_file
             .validate()
             .map_err(validation::ValidationError::from)
             .map_err(|e| format!("{}", e))
-            .err()
-        {
-            assert_eq!(actual, expected);
-        } else {
-            assert_eq!("no errors", expected);
-        };
+            .err();
+        assert_eq!(actual.as_deref(), expected);
     }
 }

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -11,7 +11,7 @@ use validator::{Validate, ValidationError};
 lazy_static! {
     static ref ALLOWED_FILENAME_CHARS: Regex = Regex::new(r"^[\w\s\.-]+$").expect("bad regex");
     static ref ALLOWED_EXTENSIONS: Regex = Regex::new(
-        r"(?x)^[\w\s\.-]+\.(
+        r"(?x)\.(
             (bmp)|
             (doc)|
             (docx)|
@@ -193,25 +193,33 @@ mod test {
     use super::*;
     use test_case::test_case;
 
-    #[test_case("filename.doc", Some("application/msword"), "no errors" ; "good extension doc")]
-    #[test_case("filename.docx", Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"), "no errors" ; "good extension docx")]
-    #[test_case("image.png", Some("image/png"), "no errors" ; "good mime type")]
-    #[test_case("image.png", Some("image/gif"), "the file extension is not valid for the specified MIME type" ; "bad mime type")]
-    #[test_case("filename.zip", None, "the file name does not have an allowed extension" ; "bad extension zip")]
-    #[test_case("filename.txt", Some("text/plain"), "no errors" ; "good extension has final dot")]
-    #[test_case("filenametxt", None, "the file name does not have an allowed extension" ; "bad extension no final dot")]
-    #[test_case(".doc", None, "\
+    #[test_case("filename.doc", Some("application/msword"), "no errors"
+        ; "good extension doc")]
+    #[test_case("filename.docx", Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"), "no errors"
+        ; "good extension docx")]
+    #[test_case("image.png", Some("image/png"), "no errors"
+        ; "good mime type")]
+    #[test_case("image.png", Some("image/gif"), "the file extension is not valid for the specified MIME type"
+        ; "bad mime type")]
+    #[test_case("filename.zip", None, "the file name does not have an allowed extension"
+        ; "bad extension zip")]
+    #[test_case("filename.txt", Some("text/plain"), "no errors"
+        ; "good extension has dot")]
+    #[test_case("filenametxt", None, "the file name does not have an allowed extension"
+        ; "bad extension no dot")]
+    #[test_case(".doc", None, "the file name must be between 5 and 255 characters long"
+        ; "too short")]
+    #[test_case("%.doc", None, "the file name contains characters that are not alphanumeric, space, period, hyphen or underscore"
+        ; "bad char percent")]
+    #[test_case("%", None, "\
         the file name must be between 5 and 255 characters long, \
-        the file name does not have an allowed extension"; "too short")]
-    #[test_case("%.doc", None, "\
         the file name contains characters that are not alphanumeric, space, period, hyphen or underscore, \
-        the file name does not have an allowed extension"; "bad char percent")]
-    #[test_case("🦀.doc", None, "\
-        the file name contains characters that are not alphanumeric, space, period, hyphen or underscore, \
-        the file name does not have an allowed extension" ; "bad char emoji")]
-    #[test_case("xx\u{0}.doc", None, "\
-        the file name contains characters that are not alphanumeric, space, period, hyphen or underscore, \
-        the file name does not have an allowed extension"; "null char")]
+        the file name does not have an allowed extension"
+        ; "multiple errors")]
+    #[test_case("🦀.doc", None, "the file name contains characters that are not alphanumeric, space, period, hyphen or underscore"
+        ; "bad char emoji")]
+    #[test_case("xx\u{0}.doc", None, "the file name contains characters that are not alphanumeric, space, period, hyphen or underscore"
+        ; "null char")]
     fn validate_filename(file_name: &str, file_type: Option<&str>, expected: &str) {
         let new_file = NewFile {
             title: "".to_string(),

--- a/workspace-service/src/graphql/mod.rs
+++ b/workspace-service/src/graphql/mod.rs
@@ -7,6 +7,7 @@ mod schema;
 #[cfg(test)]
 mod test_mocks;
 mod users;
+mod validation;
 mod workspaces;
 
 use super::azure;

--- a/workspace-service/src/graphql/validation.rs
+++ b/workspace-service/src/graphql/validation.rs
@@ -1,0 +1,43 @@
+use std::fmt::Display;
+
+use validator::{ValidationErrors, ValidationErrorsKind};
+
+pub struct ValidationError(ValidationErrors);
+
+impl Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let errors = self.0.clone().into_errors();
+        let errors = errors.iter().map(|(_, v)| v);
+        write!(
+            f,
+            "{}",
+            errors
+                .map(|e| match e {
+                    ValidationErrorsKind::Field(e) => {
+                        let s = e
+                            .iter()
+                            .map(|e| {
+                                e.message
+                                    .clone()
+                                    .map(|e| e.into_owned())
+                                    .unwrap_or_else(|| "".to_string())
+                            })
+                            .collect::<Vec<String>>()
+                            .join(", ");
+                        s
+                    }
+                    ValidationErrorsKind::Struct(e) =>
+                        format!("{}", ValidationError::from(*e.clone())),
+                    _ => "".to_string(),
+                })
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
+
+impl From<ValidationErrors> for ValidationError {
+    fn from(errors: ValidationErrors) -> Self {
+        Self(errors)
+    }
+}

--- a/workspace-service/src/graphql/validation.rs
+++ b/workspace-service/src/graphql/validation.rs
@@ -7,30 +7,28 @@ pub struct ValidationError(ValidationErrors);
 
 impl Display for ValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let errors = self.0.clone().into_errors();
-        let errors = errors.iter().map(|(_, v)| v);
-        write!(
-            f,
-            "{}",
-            errors
-                .map(|e| match e {
-                    ValidationErrorsKind::Field(e) => e
-                        .iter()
-                        .map(|e| {
-                            e.message
-                                .clone()
-                                .map(|e| e.into_owned())
-                                .unwrap_or_else(|| "".to_string())
-                        })
-                        .collect::<Vec<String>>()
-                        .join(SEPARATOR),
-                    ValidationErrorsKind::Struct(e) =>
-                        format!("{}", ValidationError::from(*e.clone())),
-                    _ => "".to_string(),
-                })
-                .collect::<Vec<String>>()
-                .join(SEPARATOR)
-        )
+        let s = self
+            .0
+            .errors()
+            .values()
+            .map(|e| match e {
+                ValidationErrorsKind::Field(e) => e
+                    .iter()
+                    .map(|e| {
+                        e.message
+                            .clone()
+                            .map(|e| e.into_owned())
+                            .unwrap_or_else(|| "".to_string())
+                    })
+                    .collect::<Vec<String>>()
+                    .join(SEPARATOR),
+                ValidationErrorsKind::Struct(e) => format!("{}", ValidationError::from(*e.clone())),
+                _ => "".to_string(),
+            })
+            .collect::<Vec<String>>()
+            .join(SEPARATOR);
+
+        write!(f, "{}", s)
     }
 }
 

--- a/workspace-service/src/graphql/validation.rs
+++ b/workspace-service/src/graphql/validation.rs
@@ -1,11 +1,12 @@
-use std::fmt::Display;
-
+use std::fmt::{Display, Formatter, Result};
 use validator::{ValidationErrors, ValidationErrorsKind};
+
+const SEPARATOR: &str = ", ";
 
 pub struct ValidationError(ValidationErrors);
 
 impl Display for ValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let errors = self.0.clone().into_errors();
         let errors = errors.iter().map(|(_, v)| v);
         write!(
@@ -13,25 +14,22 @@ impl Display for ValidationError {
             "{}",
             errors
                 .map(|e| match e {
-                    ValidationErrorsKind::Field(e) => {
-                        let s = e
-                            .iter()
-                            .map(|e| {
-                                e.message
-                                    .clone()
-                                    .map(|e| e.into_owned())
-                                    .unwrap_or_else(|| "".to_string())
-                            })
-                            .collect::<Vec<String>>()
-                            .join(", ");
-                        s
-                    }
+                    ValidationErrorsKind::Field(e) => e
+                        .iter()
+                        .map(|e| {
+                            e.message
+                                .clone()
+                                .map(|e| e.into_owned())
+                                .unwrap_or_else(|| "".to_string())
+                        })
+                        .collect::<Vec<String>>()
+                        .join(SEPARATOR),
                     ValidationErrorsKind::Struct(e) =>
                         format!("{}", ValidationError::from(*e.clone())),
                     _ => "".to_string(),
                 })
                 .collect::<Vec<String>>()
-                .join(", ")
+                .join(SEPARATOR)
         )
     }
 }


### PR DESCRIPTION
This PR extracts the `message` property from the `ValidationErrors` and comma separates them for better display in the UI.
It also uses this in the tests, adding some more tests that exposed a bug in one of the validation regular expressions.