### PR TITLE
install-argo-cd.sh cleanups

### DIFF
--- a/infrastructure/scripts/install-argo-cd.sh
+++ b/infrastructure/scripts/install-argo-cd.sh
@@ -39,7 +39,7 @@ else
 fi
 
 echo "Installing Argo CD CLI"
-brew install argoproj/tap/argocd || {
+brew install argoproj/tap/argocd || brew upgrade argocd || {
 	echo 'Unable to install.'
 	exit 1
 }
@@ -80,5 +80,9 @@ if ! argocd login --username admin --password $POD_NAME; then
 		exit 1
 	fi
 fi
+
+for app in $(argocd app list -o name); do
+	argocd app sync $app
+done
 
 echo "Your argocd username for the web ui is 'admin' and password is '$POD_NAME'"


### PR DESCRIPTION
Tiny PR to make install-argo-cd.sh:

* handle when your argocd is outdated.
* sync all apps before returning.

![](https://www.vacuumland.org/TD/VLJPEG/MODERN/2012/suctionselector++10-16-2012-10-12-24.jpg)