### PR TITLE
Workspace members

### DIFF
--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -1663,6 +1663,54 @@
                 "ofType": null
               }
             }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": "List of users in the admin group",
+            "isDeprecated": false,
+            "name": "admins",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": "List of all users who are members of this workspace",
+            "isDeprecated": false,
+            "name": "members",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            }
           }
         ],
         "inputFields": null,

--- a/workspace-service/sql/groups/group_members.sql
+++ b/workspace-service/sql/groups/group_members.sql
@@ -1,0 +1,7 @@
+SELECT
+	users.*
+FROM
+	users
+	JOIN user_groups ON users.id = user_groups.user_id
+WHERE
+	user_groups.group_id = $1

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -778,6 +778,44 @@
       ]
     }
   },
+  "c66d90fd25750d0d2094e60271dcd8e92d4ad0d110ee17d5d0e8465400461d95": {
+    "query": "SELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN user_groups ON users.id = user_groups.user_id\nWHERE\n\tuser_groups.group_id = $1\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "auth_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_platform_admin",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "cba8c2bf445a8315bdc51b6b3e87629cb2cb05186240a7731157c4f6b34ca377": {
     "query": "UPDATE folders\nSET title = COALESCE($2, title),\n    description = COALESCE($3, description)\nWHERE id = $1\nRETURNING id, title, description, workspace\n",
     "describe": {

--- a/workspace-service/src/db/users.rs
+++ b/workspace-service/src/db/users.rs
@@ -2,7 +2,9 @@
 #![allow(clippy::suspicious_else_formatting)]
 
 use anyhow::Result;
-use sqlx::{types::Uuid, PgPool};
+use sqlx::types::Uuid;
+#[cfg(not(test))]
+use sqlx::PgPool;
 
 #[derive(Clone)]
 pub struct User {
@@ -40,7 +42,7 @@ impl User {
 
 #[cfg(test)]
 impl User {
-    pub async fn find_by_auth_id(auth_id: &Uuid, _pool: &PgPool) -> Result<User> {
+    pub async fn find_by_auth_id(auth_id: &Uuid, _pool: impl Sized) -> Result<User> {
         Ok(User {
             id: Uuid::new_v4(),
             auth_id: *auth_id,
@@ -49,7 +51,7 @@ impl User {
         })
     }
 
-    pub async fn get_or_create(auth_id: &Uuid, name: &str, _pool: &PgPool) -> Result<User> {
+    pub async fn get_or_create(auth_id: &Uuid, name: &str, _pool: impl Sized) -> Result<User> {
         Ok(User {
             id: Uuid::new_v4(),
             auth_id: *auth_id,
@@ -58,7 +60,11 @@ impl User {
         })
     }
 
-    pub async fn update(auth_id: &Uuid, is_platform_admin: bool, _pool: &PgPool) -> Result<User> {
+    pub async fn update(
+        auth_id: &Uuid,
+        is_platform_admin: bool,
+        _pool: impl Sized,
+    ) -> Result<User> {
         Ok(User {
             id: Uuid::new_v4(),
             auth_id: *auth_id,

--- a/workspace-service/src/graphql/users.rs
+++ b/workspace-service/src/graphql/users.rs
@@ -50,7 +50,7 @@ impl UsersMutation {
         context: &Context<'_>,
         new_user: NewUser,
     ) -> FieldResult<User> {
-        let pool = context.data()?;
+        let pool: &PgPool = context.data()?;
         let auth_id = Uuid::parse_str(&new_user.auth_id)?;
 
         Ok(db::User::get_or_create(&auth_id, &new_user.name, pool)

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -1,12 +1,11 @@
 use crate::db;
 use crate::graphql::RequestingUser;
-use async_graphql::{Context, FieldResult, InputObject, Object, SimpleObject, ID};
+use async_graphql::{Context, FieldResult, InputObject, Object, ID};
 use fnhs_event_models::{Event, EventClient, EventPublisher as _, WorkspaceCreatedData};
 use sqlx::PgPool;
 use uuid::Uuid;
 
 /// A workspace
-#[derive(SimpleObject)]
 pub struct Workspace {
     /// The id of the workspace
     id: ID,
@@ -14,6 +13,21 @@ pub struct Workspace {
     title: String,
     /// The description of the workspace
     description: String,
+}
+
+#[Object]
+impl Workspace {
+    async fn id(&self) -> ID {
+        self.id.clone()
+    }
+
+    async fn title(&self) -> String {
+        self.title.clone()
+    }
+
+    async fn description(&self) -> String {
+        self.description.clone()
+    }
 }
 
 impl From<db::Workspace> for Workspace {

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -1,32 +1,47 @@
 use crate::db;
+use crate::graphql::users::User;
 use crate::graphql::RequestingUser;
 use async_graphql::{Context, FieldResult, InputObject, Object, ID};
 use fnhs_event_models::{Event, EventClient, EventPublisher as _, WorkspaceCreatedData};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-/// A workspace
 pub struct Workspace {
-    /// The id of the workspace
     id: ID,
-    /// The title of the workspace
     title: String,
-    /// The description of the workspace
     description: String,
+    admins: Uuid,
+    members: Uuid,
 }
 
 #[Object]
+/// A workspace
 impl Workspace {
+    /// The id of the workspace
     async fn id(&self) -> ID {
         self.id.clone()
     }
-
+    /// The title of the workspace
     async fn title(&self) -> String {
         self.title.clone()
     }
-
+    /// The description of the workspace
     async fn description(&self) -> String {
         self.description.clone()
+    }
+
+    /// List of users in the admin group
+    async fn admins(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
+        let pool = context.data()?;
+        let users = db::Group::group_members(self.admins, pool).await?;
+        Ok(users.into_iter().map(Into::into).collect())
+    }
+
+    /// List of all users who are members of this workspace
+    async fn members(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
+        let pool = context.data()?;
+        let users = db::Group::group_members(self.members, pool).await?;
+        Ok(users.into_iter().map(Into::into).collect())
     }
 }
 
@@ -36,6 +51,8 @@ impl From<db::Workspace> for Workspace {
             id: d.id.into(),
             title: d.title,
             description: d.description,
+            admins: d.admins,
+            members: d.members,
         }
     }
 }


### PR DESCRIPTION
[AB#2072](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/2072)

[Zeplin](https://www.figma.com/file/tYFsqhG61CleWS1tUapAar/Source-of-Truth-UI?node-id=601%3A7209)


## Acceptance Criteria

## Pre-review checklist:

- [ ] ~Tests~ all very thin shims, so not covered by tests. Type coverage seems enough.

- [x] Documentation

- [ ] ~Analytics (user analytics, e.g. Google Analytics)~

- [ ] ~Observability (metrics/tracing)~

- [ ] ~Feature flag~

- [ ] ~Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)~

## Testing information

There aren't any user-visible changes in this PR.

- Is there any special setup required?

setup can be done in tableplus (happy to pair)
```
query {
  workspaces {
    id, title,
    admins {id, authId, name}
  }
}
```
gives:
```
{
  "data": {
    "workspaces": [
      {
        "admins": [
          {
            "authId": "feedface-0000-0000-0000-000000000000",
            "id": "8b0381c9-6288-4bab-8bcd-e61c6e5b14ec",
            "name": "Initial Admin User"
          }
        ],
        "id": "b3f0e8ac-5527-4f4b-bf70-63ef7b727147",
        "title": "Selenium Testing"
      }
    ]
  }
}
```

- Test plan?

## Test:

- [x] Tested locally


![GROUP HUG](https://media.giphy.com/media/WOIGpnJ3ye445BUQl4/giphy-downsized.gif)