### PR TITLE
[BUG 2322] Fix font size for workspace nav links

### DIFF
--- a/frontend/components/Navigation/Navigation.tsx
+++ b/frontend/components/Navigation/Navigation.tsx
@@ -63,6 +63,7 @@ const LinkList = styled.ul`
 
 const LinkListItem = styled.li`
   list-style-type: none;
+  font-size: 16px;
 `;
 
 interface Props {

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -268,6 +268,7 @@ exports[`<Navigation/> renders correctly 1`] = `
 
 .c4 {
   list-style-type: none;
+  font-size: 16px;
 }
 
 @media (min-width:990px) {


### PR DESCRIPTION
<img src="https://media.giphy.com/media/eslk6GMwjUYq50A3Jl/giphy.gif" />

[BUG 2322 [Workspace Navigation] 'About workspace' and 'View members' links should be 16px](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2322)

## Acceptance Criteria
- [x] Change the 'About workspace' and 'View members' links to 16px

## Pre-review checklist:

- [x] Tests

~~- [ ] Documentation~~

~~- [ ] Analytics (user analytics, e.g. Google Analytics)~~

~~- [ ] Observability (metrics/tracing)~~

~~- [ ] Feature flag~~

~~- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)~~

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [x] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
