### PR TITLE
[BUG 2257] Increase z-index of nav list

### DIFF
--- a/frontend/components/NavHeader/NavList.tsx
+++ b/frontend/components/NavHeader/NavList.tsx
@@ -40,6 +40,7 @@ const StyledCloseIconWrapper = styled.button`
 const StyledNavMenuContainer = styled.nav`
   width: 100%;
   right: 0;
+  z-index: 10;
 
   ${({ theme }) => `
     @media (min-width: ${theme.mqBreakpoints.largeDesktop}) {

--- a/frontend/components/NavHeader/__snapshots__/NavHeader.test.tsx.snap
+++ b/frontend/components/NavHeader/__snapshots__/NavHeader.test.tsx.snap
@@ -513,6 +513,7 @@ exports[`<NavHeader/> shows menu when open 1`] = `
 .c8 {
   width: 100%;
   right: 0;
+  z-index: 10;
   background-color: rgb(255,255,255);
   border-left: 1px solid rgb(240,244,245);
   border-bottom: 1px solid rgb(240,244,245);


### PR DESCRIPTION
<img src="https://media.giphy.com/media/6bh9FTTEKdtZe/giphy.gif" />

[BUG 2257 [Folder view] The folder header meatball menu appears on top of the nav bar menu when opened](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2257)

## Acceptance Criteria
- [x] The nav menu dropdown should appear above everything.

## Pre-review checklist:

- [ ] Tests

~~- [ ] Documentation~~

~~- [ ] Analytics (user analytics, e.g. Google Analytics)~~

~~- [ ] Observability (metrics/tracing)~~

~~- [ ] Feature flag~~

~~- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)~~

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
