### PR TITLE
Bug 2256 - Remove outline from options 

### DIFF
--- a/frontend/components/Menu/MenuButton.tsx
+++ b/frontend/components/Menu/MenuButton.tsx
@@ -68,6 +68,8 @@ const StyledMenuButton = styled(MenuButton)`
       color: ${({ theme }) => theme.colorNhsukBlack};
     }
     background-color: ${({ theme }) => theme.colorNhsukYellow};
+    outline: none;
+    border-bottom: 2px solid black;
   }
 
   border-radius: 4px;

--- a/frontend/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/frontend/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -75,6 +75,8 @@ exports[`Menu takes a snapshot, as used in a page 1`] = `
   opacity: 1;
   color: rgb(33,43,50);
   background-color: rgb(255,235,59);
+  outline: none;
+  border-bottom: 2px solid black;
 }
 
 .c3.open.hidden,
@@ -240,6 +242,8 @@ exports[`Menu takes a snapshot, as used in the nav 1`] = `
   opacity: 1;
   color: rgb(33,43,50);
   background-color: rgb(255,235,59);
+  outline: none;
+  border-bottom: 2px solid black;
 }
 
 .c3.open.hidden,

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -91,6 +91,8 @@ exports[`<Navigation/> renders correctly 1`] = `
   opacity: 1;
   color: rgb(33,43,50);
   background-color: rgb(255,235,59);
+  outline: none;
+  border-bottom: 2px solid black;
 }
 
 .c12.open.hidden,


### PR DESCRIPTION
[Bug 2256 [Folder Navigation] Meatball menu has an outline when active/focused](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2256)

## Acceptance Criteria
- [x] Meatball menu shouldn't have the blue outline.

## Pre-review checklist:

- [ ] Tests

- [ ] Documentation

- [ ] Analytics (user analytics, e.g. Google Analytics)

- [ ] Observability (metrics/tracing)

- [ ] Feature flag

- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
