### PR TITLE
❓ use db::Workspace everywhere, and don't have a graphql::Workspace struct

### DIFF
--- a/workspace-service/Makefile
+++ b/workspace-service/Makefile
@@ -34,8 +34,8 @@ check: ## Run `cargo check` (because David keeps saying "make check" when he mea
 	cargo check
 
 .PHONY: clippy
-clippy: ## Run `cargo clippy`, the Rust linter.
-	cargo clippy
+clippy: ## Run `cargo clippy`, the Rust linter. --release is to get around some interactions with cargo check.
+	cargo clippy --release -- -D warnings
 
 .PHONY: fmt
 fmt: ## Run `cargo fmt` (convenience so that you can write `make fmt check test clippy` in one command)

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -72,7 +72,7 @@ impl WorkspacesQuery {
         let pool = context.data()?;
         let id = Uuid::parse_str(id.as_str())?;
         let workspace = db::Workspace::find_by_id(id, pool).await?;
-        Ok(workspace.into())
+        Ok(workspace)
     }
 }
 
@@ -118,7 +118,7 @@ impl WorkspacesMutation {
         )
         .await?;
 
-        Ok(workspace.into())
+        Ok(workspace)
     }
 
     /// Delete workspace(returns deleted workspace
@@ -127,7 +127,7 @@ impl WorkspacesMutation {
         let pool = context.data()?;
         let workspace = db::Workspace::delete(Uuid::parse_str(id.as_str())?, pool).await?;
 
-        Ok(workspace.into())
+        Ok(workspace)
     }
 }
 

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -1,6 +1,5 @@
 use crate::db;
-use crate::db::Workspace;
-use crate::graphql::users::User;
+use crate::db::{User, Workspace};
 use crate::graphql::RequestingUser;
 use async_graphql::{Context, FieldResult, InputObject, Object, ID};
 use fnhs_event_models::{Event, EventClient, EventPublisher as _, WorkspaceCreatedData};
@@ -27,14 +26,14 @@ impl Workspace {
     async fn admins(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
         let pool = context.data()?;
         let users = db::Group::group_members(self.admins, pool).await?;
-        Ok(users.into_iter().map(Into::into).collect())
+        Ok(users)
     }
 
     /// List of all users who are members of this workspace
     async fn members(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
         let pool = context.data()?;
         let users = db::Group::group_members(self.members, pool).await?;
-        Ok(users.into_iter().map(Into::into).collect())
+        Ok(users)
     }
 }
 

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -59,7 +59,7 @@ impl WorkspacesQuery {
     async fn workspaces(&self, context: &Context<'_>) -> FieldResult<Vec<Workspace>> {
         let pool = context.data()?;
         let workspaces = db::Workspace::find_all(pool).await?;
-        Ok(workspaces.into_iter().map(Into::into).collect())
+        Ok(workspaces)
     }
 
     /// Get workspace by ID


### PR DESCRIPTION
Crazy idea: Now that Workspace is no longer a SimpleObject, we can probably get away without a graphql::Workspace struct entirely. The methods on `#[Object] impl Workspace` replace the need for a `impl From<db::Workspace> for Workspace {` and the GraphQL schema stays the same.

If we're doing this then we should *probably* apply the same treatment to all of our models.

Upsides include:

* No need to keep track of which `Workspace` struct we mean.
* No mostly-passthrough .into() implementation.
* Easier and more natural to extend our objects with resolvers that optionally fetch from the DB at a later date.

Downsides include:

* We have an `impl Struct` that doesn't live in the same place as `struct Struct {}`
  * Splitting impl blocks up into different modules is actually surprisingly common in rust-land, so this might just be fine.
* The `#[Object]` attribute macro is super-magical, and the methods you write end up with a completely different signature from what you expect (Workspace already has this problem, but we would be extending it to all of our models).

![kill it with fire?](https://media.giphy.com/media/j6vp6NJcZBO1A0EYY8/giphy.gif)