### PR TITLE
Type helpers and cleanup for urql cache

### DIFF
--- a/frontend/lib/withUrqlClient.ts
+++ b/frontend/lib/withUrqlClient.ts
@@ -50,7 +50,7 @@ type PartialChildren<T> = {
 };
 
 type MutationUpdatesConfig = {
-  [K in keyof Exclude<Mutation, "__typename">]?: (
+  [K in keyof Omit<Mutation, "__typename">]?: (
     result: Data & PartialChildren<Pick<Mutation, K>>,
     // TODO: Ideally the typescript-urql generator could generate a map with
     // the same keys as `Mutation` where the values are the corresponding

--- a/frontend/lib/withUrqlClient.ts
+++ b/frontend/lib/withUrqlClient.ts
@@ -28,10 +28,12 @@ const workspaceAPIServerUrl = isServerSide
 
 /**
  * Creates an updater for a given Query type.
+ *
+ * This doesn't change any behaviour. It's purely a type cast.
  */
 const updateWithNull = <T extends { __typename?: "Query" }>(
   handler: (data: (Data & T) | null) => (Data & T) | null
-) => (data: Data | null) => handler(data as (Data & T) | null) as Data | null;
+): ((data: Data | null) => Data | null) => handler as any;
 
 /**
  * Creates an updater for a given Query type, which performs no update if the

--- a/frontend/lib/withUrqlClient.ts
+++ b/frontend/lib/withUrqlClient.ts
@@ -69,7 +69,9 @@ const mutationUpdateResolvers: MutationUpdatesConfig = {
   createFolder: (result, args: CreateFolderMutationVariables, cache) => {
     const { __typename, id, title } = result.createFolder;
     if (id === undefined || title === undefined) {
-      cache.invalidate("Query", "createFolder", { workspace: args.workspace });
+      cache.invalidate("Query", "foldersByWorkspace", {
+        workspace: args.workspace,
+      });
     } else {
       cache.updateQuery(
         {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1432,7 +1432,7 @@
   dependencies:
     "@types/node" "^14.14.6"
     ajv "^6.12.6"
-    typescript "^4.0.3"
+    typescript "^4.0.5"
 
 "@graphql-codegen/cli@1.17.10":
   version "1.17.10"
@@ -12533,10 +12533,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.2, typescript@^4.0.3:
+typescript@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.22"


### PR DESCRIPTION
We had a few problems with the urql cache recently, which were due to not fully understanding how it works and the loose typing it provides. This PR changes 2 things:

- It adds types for mutations in the cache exchange. This means if you update the cache for the `createFolder` mutation, you always get a properly types `Folder` response to work with.

  However, since the mutation doesn't guarantee, which fields are returned, it's a `Partial<Folder>`. This shows nicely where we actually have to add more checks.

- It adds `update` helper functions, which make it easier to cast cache responses to our appropriate types without accidentally loosing nullability.

  We used to write code like this:

  ```ts
  cache.updateQuery(
    {
      query: FilesByFolderDocument,
      variables: { folder: mutationResult.deleteFile.folder, },
    },
    (data) => {
      const filesByFolderQuery = data as FilesByFolderQuery | null; // <-- This "| null" is super easy to forget
      if (filesByFolderQuery === null) return null;
      // Perform updates
      return data;
    }
  );
  ```

  With the helper you would write:

  ```ts
  cache.updateQuery(
    {
      query: FilesByFolderDocument,
      variables: { folder: mutationResult.deleteFile.folder, },
    },
    update<FilesByFolderQuery>((data) => { // Null check happens automatically. This function only gets called with it's not null
      // Perform updates
      return data;
    })
  );
  ```

- We were doing some unnecessarily complex cache updates.

  urqls caching is actually quite smart. Based on `__typename` and `id` fields it builds up a flat cache. When a mutation returns objects with the same `__typename` and `id` as items in the cache, those are automatically updated. This means we don't need custom cache updates for any mutation that updates.

  For mutations, that delete items, urql has a helper called `cache.invalidate`. This will remove all items from the cache with the same  `__typename` and `id` as the object passed in. And this will affect all queries that previously returned this item.