### PR TITLE
rename groups to teams in db

### DIFF
--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -1697,7 +1697,7 @@
           {
             "args": [],
             "deprecationReason": null,
-            "description": "List of users in the admin group",
+            "description": "List of users in the admin team",
             "isDeprecated": false,
             "name": "admins",
             "type": {

--- a/workspace-service/migrations/20201102110421_rename-group-to-teamteam.sql
+++ b/workspace-service/migrations/20201102110421_rename-group-to-teamteam.sql
@@ -1,0 +1,9 @@
+ALTER TABLE groups
+RENAME TO teams;
+
+-- link_ prefix to call it out as being a link table.
+-- (This isn't in any style guide or anything. Just seemed like a good idea)
+ALTER TABLE user_groups
+RENAME TO link_users_teams;
+ALTER TABLE link_users_teams
+RENAME COLUMN group_id to team_id;

--- a/workspace-service/sql/groups/group_members.sql
+++ b/workspace-service/sql/groups/group_members.sql
@@ -1,7 +1,0 @@
-SELECT
-	users.*
-FROM
-	users
-	JOIN user_groups ON users.id = user_groups.user_id
-WHERE
-	user_groups.group_id = $1

--- a/workspace-service/sql/teams/create.sql
+++ b/workspace-service/sql/teams/create.sql
@@ -1,3 +1,3 @@
-INSERT INTO groups (title)
+INSERT INTO teams (title)
 VALUES ($1)
 RETURNING id, title

--- a/workspace-service/sql/teams/members.sql
+++ b/workspace-service/sql/teams/members.sql
@@ -1,0 +1,7 @@
+SELECT
+	users.*
+FROM
+	users
+	JOIN link_users_teams ON users.id = link_users_teams.user_id
+WHERE
+	link_users_teams.team_id = $1

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -251,6 +251,76 @@
       ]
     }
   },
+  "2f057012b2ccd0571b02a7442f8f58e2af231e709f2b400e38646ed7587bbfe6": {
+    "query": "INSERT INTO teams (title)\nVALUES ($1)\nRETURNING id, title\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "title",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "30ca906859817bb8fe8e85b4029315fa6366ab50ce91b0ed0bf36c48ebd788e9": {
+    "query": "SELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN link_users_teams ON users.id = link_users_teams.user_id\nWHERE\n\tlink_users_teams.team_id = $1\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "auth_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_platform_admin",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "email_address",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "394f0934d95043c252988e7d90476223a7b1ad35c4366f60c4c81d676d3f0109": {
     "query": "SELECT * FROM users WHERE auth_id = $1;\n",
     "describe": {
@@ -568,32 +638,6 @@
       ]
     }
   },
-  "7f370d618ab06ac5ed68d1b77f493af2bbfd3b6f6ad606711896f66fcbac926b": {
-    "query": "INSERT INTO groups (title)\nVALUES ($1)\nRETURNING id, title\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "title",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
   "93c4976d0825c426eec25dd14c201e8ba4bbf4df8fa17280c583cf20f3dbbe64": {
     "query": "DELETE FROM workspaces\nWHERE id = $1\nRETURNING *\n",
     "describe": {
@@ -734,50 +778,6 @@
           "Uuid",
           "Text",
           "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "c66d90fd25750d0d2094e60271dcd8e92d4ad0d110ee17d5d0e8465400461d95": {
-    "query": "SELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN user_groups ON users.id = user_groups.user_id\nWHERE\n\tuser_groups.group_id = $1\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "auth_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "is_platform_admin",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 4,
-          "name": "email_address",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
         ]
       },
       "nullable": [

--- a/workspace-service/src/db/mod.rs
+++ b/workspace-service/src/db/mod.rs
@@ -1,14 +1,14 @@
 mod file_versions;
 mod files;
 mod folders;
-mod groups;
+mod teams;
 mod users;
 mod workspaces;
 
 pub use file_versions::*;
 pub use files::*;
 pub use folders::*;
-pub use groups::*;
+pub use teams::*;
 pub use users::*;
 pub use workspaces::*;
 #[cfg(not(test))]

--- a/workspace-service/src/db/teams.rs
+++ b/workspace-service/src/db/teams.rs
@@ -7,28 +7,28 @@ use sqlx::types::Uuid;
 use sqlx::{Executor, Postgres};
 
 #[derive(Clone)]
-pub struct Group {
+pub struct Team {
     pub id: Uuid,
     pub title: String,
 }
 
 #[cfg(not(test))]
-impl Group {
-    pub async fn create<'c, E>(title: &str, executor: E) -> Result<Group>
+impl Team {
+    pub async fn create<'c, E>(title: &str, executor: E) -> Result<Team>
     where
         E: Executor<'c, Database = Postgres>,
     {
-        let group = sqlx::query_file_as!(Group, "sql/groups/create.sql", title)
+        let group = sqlx::query_file_as!(Team, "sql/teams/create.sql", title)
             .fetch_one(executor)
             .await?;
 
         Ok(group)
     }
-    pub async fn group_members<'c, E>(id: Uuid, executor: E) -> Result<Vec<User>>
+    pub async fn members<'c, E>(id: Uuid, executor: E) -> Result<Vec<User>>
     where
         E: Executor<'c, Database = Postgres>,
     {
-        let users = sqlx::query_file_as!(User, "sql/groups/group_members.sql", id)
+        let users = sqlx::query_file_as!(User, "sql/teams/members.sql", id)
             .fetch_all(executor)
             .await?;
 
@@ -39,20 +39,20 @@ impl Group {
 // Fake implementation for tests. If you want integration tests that exercise the database,
 // see https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html.
 #[cfg(test)]
-impl Group {
+impl Team {
     #[allow(dead_code)]
-    pub async fn create<'c, E>(title: &str, _executor: E) -> Result<Group>
+    pub async fn create<'c, E>(title: &str, _executor: E) -> Result<Team>
     where
         E: Executor<'c, Database = Postgres>,
     {
-        let group = Group {
+        let group = Team {
             id: Uuid::new_v4(),
             title: title.to_string(),
         };
         Ok(group)
     }
 
-    pub async fn group_members<'c, E>(id: Uuid, executor: E) -> Result<Vec<User>>
+    pub async fn members<'c, E>(id: Uuid, executor: E) -> Result<Vec<User>>
     where
         E: Executor<'c, Database = Postgres>,
     {

--- a/workspace-service/src/db/workspaces.rs
+++ b/workspace-service/src/db/workspaces.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::suspicious_else_formatting)]
 
 #[cfg(not(test))]
-use crate::db::Group;
+use crate::db::Team;
 use anyhow::Result;
 use sqlx::{types::Uuid, PgPool};
 
@@ -20,8 +20,8 @@ impl Workspace {
     pub async fn create(title: &str, description: &str, pool: &PgPool) -> Result<Workspace> {
         let mut tx = pool.begin().await?;
 
-        let admins = Group::create(&format!("{} Admins", title), &mut tx).await?;
-        let members = Group::create(&format!("{} Members", title), &mut tx).await?;
+        let admins = Team::create(&format!("{} Admins", title), &mut tx).await?;
+        let members = Team::create(&format!("{} Members", title), &mut tx).await?;
 
         let workspace = sqlx::query_file_as!(
             Workspace,

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -30,17 +30,17 @@ impl Workspace {
         self.description.clone()
     }
 
-    /// List of users in the admin group
+    /// List of users in the admin team
     async fn admins(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
         let pool = context.data()?;
-        let users = db::Group::group_members(self.admins, pool).await?;
+        let users = db::Team::members(self.admins, pool).await?;
         Ok(users.into_iter().map(Into::into).collect())
     }
 
     /// List of all users who are members of this workspace
     async fn members(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
         let pool = context.data()?;
-        let users = db::Group::group_members(self.members, pool).await?;
+        let users = db::Team::members(self.members, pool).await?;
         Ok(users.into_iter().map(Into::into).collect())
     }
 }


### PR DESCRIPTION
Part of [AB#2072](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/2072)

## Acceptance Criteria

Team matches the domain language a bit better. Also, GROUP is a reserved word in SQL ;-)

## Pre-review checklist:

- [x] ~Feature flag~ Deployability. This is not a zero-downtime deploy: while the new code is rolling out, the old code will not work. Best to do this now, before we have any users.

- [x] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government) - Dublin Core Metadata schema doesn't seem to have anything to say on the matter. I might be missing something though.

## Test:

- [x] Tested locally

Everything related to column names is tied together and checked by sqlx, so I don't expect anything to break here. 

![](https://media.giphy.com/media/w8PYWpLU04PXipfo3f/giphy-downsized.gif)
