### PR TITLE
Add analytics events

### DIFF
--- a/event-models/rust/src/models/generated.rs
+++ b/event-models/rust/src/models/generated.rs
@@ -9,10 +9,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContentViewedData {
     ///
-    #[serde(rename = "userId")]
-    pub user_id: String,
-
-    ///
     #[serde(rename = "contentId")]
     pub content_id: String,
 
@@ -21,32 +17,28 @@ pub struct ContentViewedData {
     pub content_type: String,
 
     ///
-    #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
-
-    ///
     #[serde(rename = "error", skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+
+    ///
+    #[serde(rename = "userId")]
+    pub user_id: String,
+
+    ///
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
 }
 
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FileCreatedData {
-    ///
-    #[serde(rename = "fileId")]
-    pub file_id: String,
-
     /// The date at which the file has been created
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>,
 
-    /// The folder that the file is in
-    #[serde(rename = "folderId")]
-    pub folder_id: String,
-
-    /// The workspace that the file is in
-    #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
+    ///
+    #[serde(rename = "fileId")]
+    pub file_id: String,
 
     ///
     #[serde(rename = "fileTitle")]
@@ -60,6 +52,14 @@ pub struct FileCreatedData {
     #[serde(rename = "fileType")]
     pub file_type: String,
 
+    /// The folder that the file is in
+    #[serde(rename = "folderId")]
+    pub folder_id: String,
+
+    /// The user that created the file
+    #[serde(rename = "userId")]
+    pub user_id: String,
+
     ///
     #[serde(rename = "versionId")]
     pub version_id: String,
@@ -68,9 +68,9 @@ pub struct FileCreatedData {
     #[serde(rename = "versionNumber")]
     pub version_number: i64,
 
-    /// The user that created the file
-    #[serde(rename = "userId")]
-    pub user_id: String,
+    /// The workspace that the file is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
 }
 
 ///
@@ -80,18 +80,6 @@ pub struct FileUpdatedData {
     #[serde(rename = "fileId")]
     pub file_id: String,
 
-    /// The date at which the file has been updated (= the new file version has been created)
-    #[serde(rename = "updatedAt")]
-    pub updated_at: DateTime<Utc>,
-
-    /// The folder that the file is in
-    #[serde(rename = "folderId")]
-    pub folder_id: String,
-
-    /// The workspace that the file is in
-    #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
-
     ///
     #[serde(rename = "fileTitle")]
     pub file_title: String,
@@ -104,6 +92,18 @@ pub struct FileUpdatedData {
     #[serde(rename = "fileType")]
     pub file_type: String,
 
+    /// The folder that the file is in
+    #[serde(rename = "folderId")]
+    pub folder_id: String,
+
+    /// The date at which the file has been updated (= the new file version has been created)
+    #[serde(rename = "updatedAt")]
+    pub updated_at: DateTime<Utc>,
+
+    /// The user that created the file
+    #[serde(rename = "userId")]
+    pub user_id: String,
+
     ///
     #[serde(rename = "versionId")]
     pub version_id: String,
@@ -112,9 +112,9 @@ pub struct FileUpdatedData {
     #[serde(rename = "versionNumber")]
     pub version_number: i64,
 
-    /// The user that created the file
-    #[serde(rename = "userId")]
-    pub user_id: String,
+    /// The workspace that the file is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
 }
 
 ///
@@ -169,24 +169,24 @@ pub struct FileDownloadedData {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FolderCreatedData {
     ///
+    #[serde(rename = "description")]
+    pub description: String,
+
+    ///
     #[serde(rename = "folderId")]
     pub folder_id: String,
-
-    /// The workspace that the folder is in
-    #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
 
     ///
     #[serde(rename = "title")]
     pub title: String,
 
-    ///
-    #[serde(rename = "description")]
-    pub description: String,
-
     /// The user that created the folder
     #[serde(rename = "userId")]
     pub user_id: String,
+
+    /// The workspace that the folder is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
 }
 
 ///
@@ -220,22 +220,18 @@ pub struct FolderDeletedData {
     #[serde(rename = "folderId")]
     pub folder_id: String,
 
-    /// The workspace that the folder is in
-    #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
-
     /// The user that deleted the folder
     #[serde(rename = "userId")]
     pub user_id: String,
+
+    /// The workspace that the folder is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
 }
 
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceCreatedData {
-    ///
-    #[serde(rename = "workspaceId")]
-    pub workspace_id: String,
-
     ///
     #[serde(rename = "title")]
     pub title: String,
@@ -243,6 +239,10 @@ pub struct WorkspaceCreatedData {
     /// The id of the user that created the workspace
     #[serde(rename = "userId")]
     pub user_id: String,
+
+    ///
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/event-models/rust/src/models/generated.rs
+++ b/event-models/rust/src/models/generated.rs
@@ -64,6 +64,10 @@ pub struct FileCreatedData {
     #[serde(rename = "versionId")]
     pub version_id: String,
 
+    ///
+    #[serde(rename = "versionNumber")]
+    pub version_number: i64,
+
     /// The user that created the file
     #[serde(rename = "userId")]
     pub user_id: String,
@@ -115,6 +119,30 @@ pub struct FileUpdatedData {
 
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileDeletedData {
+    ///
+    #[serde(rename = "fileId")]
+    pub file_id: String,
+
+    /// The user that deleted the file
+    #[serde(rename = "userId")]
+    pub user_id: String,
+
+    ///
+    #[serde(rename = "versionId")]
+    pub version_id: String,
+
+    ///
+    #[serde(rename = "versionNumber")]
+    pub version_number: i64,
+
+    /// The workspace that the file is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
+}
+
+///
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FolderCreatedData {
     ///
     #[serde(rename = "folderId")]
@@ -127,6 +155,10 @@ pub struct FolderCreatedData {
     ///
     #[serde(rename = "title")]
     pub title: String,
+
+    ///
+    #[serde(rename = "description")]
+    pub description: String,
 
     /// The user that created the folder
     #[serde(rename = "userId")]
@@ -154,6 +186,7 @@ pub enum EventData {
     ContentViewed(ContentViewedData),
     FileCreated(FileCreatedData),
     FileUpdated(FileUpdatedData),
+    FileDeleted(FileDeletedData),
     FolderCreated(FolderCreatedData),
     WorkspaceCreated(WorkspaceCreatedData),
 }
@@ -173,6 +206,12 @@ impl From<FileCreatedData> for EventData {
 impl From<FileUpdatedData> for EventData {
     fn from(data: FileUpdatedData) -> Self {
         Self::FileUpdated(data)
+    }
+}
+
+impl From<FileDeletedData> for EventData {
+    fn from(data: FileDeletedData) -> Self {
+        Self::FileDeleted(data)
     }
 }
 
@@ -212,6 +251,10 @@ impl EventData {
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
 
+            ("FileDeleted", "1") => Ok(Self::FileDeleted(
+                serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
+            )),
+
             ("FolderCreated", "1") => Ok(Self::FolderCreated(
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
@@ -233,6 +276,8 @@ impl EventData {
             Self::FileCreated(data) => ("FileCreated", "1", serde_json::to_value(data)?),
 
             Self::FileUpdated(data) => ("FileUpdated", "1", serde_json::to_value(data)?),
+
+            Self::FileDeleted(data) => ("FileDeleted", "1", serde_json::to_value(data)?),
 
             Self::FolderCreated(data) => ("FolderCreated", "1", serde_json::to_value(data)?),
 

--- a/event-models/rust/src/models/generated.rs
+++ b/event-models/rust/src/models/generated.rs
@@ -215,6 +215,22 @@ pub struct FolderUpdatedData {
 
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FolderDeletedData {
+    ///
+    #[serde(rename = "folderId")]
+    pub folder_id: String,
+
+    /// The workspace that the folder is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
+
+    /// The user that deleted the folder
+    #[serde(rename = "userId")]
+    pub user_id: String,
+}
+
+///
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceCreatedData {
     ///
     #[serde(rename = "workspaceId")]
@@ -238,6 +254,7 @@ pub enum EventData {
     FileDownloaded(FileDownloadedData),
     FolderCreated(FolderCreatedData),
     FolderUpdated(FolderUpdatedData),
+    FolderDeleted(FolderDeletedData),
     WorkspaceCreated(WorkspaceCreatedData),
 }
 
@@ -280,6 +297,12 @@ impl From<FolderCreatedData> for EventData {
 impl From<FolderUpdatedData> for EventData {
     fn from(data: FolderUpdatedData) -> Self {
         Self::FolderUpdated(data)
+    }
+}
+
+impl From<FolderDeletedData> for EventData {
+    fn from(data: FolderDeletedData) -> Self {
+        Self::FolderDeleted(data)
     }
 }
 
@@ -329,6 +352,10 @@ impl EventData {
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
 
+            ("FolderDeleted", "1") => Ok(Self::FolderDeleted(
+                serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
+            )),
+
             ("WorkspaceCreated", "1") => Ok(Self::WorkspaceCreated(
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
@@ -354,6 +381,8 @@ impl EventData {
             Self::FolderCreated(data) => ("FolderCreated", "1", serde_json::to_value(data)?),
 
             Self::FolderUpdated(data) => ("FolderUpdated", "1", serde_json::to_value(data)?),
+
+            Self::FolderDeleted(data) => ("FolderDeleted", "1", serde_json::to_value(data)?),
 
             Self::WorkspaceCreated(data) => ("WorkspaceCreated", "1", serde_json::to_value(data)?),
         })

--- a/event-models/rust/src/models/generated.rs
+++ b/event-models/rust/src/models/generated.rs
@@ -191,6 +191,30 @@ pub struct FolderCreatedData {
 
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FolderUpdatedData {
+    ///
+    #[serde(rename = "folderId")]
+    pub folder_id: String,
+
+    /// The workspace that the folder is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
+
+    ///
+    #[serde(rename = "title")]
+    pub title: String,
+
+    ///
+    #[serde(rename = "description")]
+    pub description: String,
+
+    /// The user that updated the folder
+    #[serde(rename = "userId")]
+    pub user_id: String,
+}
+
+///
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceCreatedData {
     ///
     #[serde(rename = "workspaceId")]
@@ -213,6 +237,7 @@ pub enum EventData {
     FileDeleted(FileDeletedData),
     FileDownloaded(FileDownloadedData),
     FolderCreated(FolderCreatedData),
+    FolderUpdated(FolderUpdatedData),
     WorkspaceCreated(WorkspaceCreatedData),
 }
 
@@ -249,6 +274,12 @@ impl From<FileDownloadedData> for EventData {
 impl From<FolderCreatedData> for EventData {
     fn from(data: FolderCreatedData) -> Self {
         Self::FolderCreated(data)
+    }
+}
+
+impl From<FolderUpdatedData> for EventData {
+    fn from(data: FolderUpdatedData) -> Self {
+        Self::FolderUpdated(data)
     }
 }
 
@@ -294,6 +325,10 @@ impl EventData {
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
 
+            ("FolderUpdated", "1") => Ok(Self::FolderUpdated(
+                serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
+            )),
+
             ("WorkspaceCreated", "1") => Ok(Self::WorkspaceCreated(
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
@@ -317,6 +352,8 @@ impl EventData {
             Self::FileDownloaded(data) => ("FileDownloaded", "1", serde_json::to_value(data)?),
 
             Self::FolderCreated(data) => ("FolderCreated", "1", serde_json::to_value(data)?),
+
+            Self::FolderUpdated(data) => ("FolderUpdated", "1", serde_json::to_value(data)?),
 
             Self::WorkspaceCreated(data) => ("WorkspaceCreated", "1", serde_json::to_value(data)?),
         })

--- a/event-models/rust/src/models/generated.rs
+++ b/event-models/rust/src/models/generated.rs
@@ -143,6 +143,30 @@ pub struct FileDeletedData {
 
 ///
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileDownloadedData {
+    ///
+    #[serde(rename = "fileId")]
+    pub file_id: String,
+
+    /// The user that downloaded the file
+    #[serde(rename = "userId")]
+    pub user_id: String,
+
+    ///
+    #[serde(rename = "versionId")]
+    pub version_id: String,
+
+    ///
+    #[serde(rename = "versionNumber")]
+    pub version_number: i64,
+
+    /// The workspace that the file is in
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
+}
+
+///
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FolderCreatedData {
     ///
     #[serde(rename = "folderId")]
@@ -187,6 +211,7 @@ pub enum EventData {
     FileCreated(FileCreatedData),
     FileUpdated(FileUpdatedData),
     FileDeleted(FileDeletedData),
+    FileDownloaded(FileDownloadedData),
     FolderCreated(FolderCreatedData),
     WorkspaceCreated(WorkspaceCreatedData),
 }
@@ -212,6 +237,12 @@ impl From<FileUpdatedData> for EventData {
 impl From<FileDeletedData> for EventData {
     fn from(data: FileDeletedData) -> Self {
         Self::FileDeleted(data)
+    }
+}
+
+impl From<FileDownloadedData> for EventData {
+    fn from(data: FileDownloadedData) -> Self {
+        Self::FileDownloaded(data)
     }
 }
 
@@ -255,6 +286,10 @@ impl EventData {
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
 
+            ("FileDownloaded", "1") => Ok(Self::FileDownloaded(
+                serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
+            )),
+
             ("FolderCreated", "1") => Ok(Self::FolderCreated(
                 serde_json::from_value(data).map_err(EventDataDeserializationError::Json)?,
             )),
@@ -278,6 +313,8 @@ impl EventData {
             Self::FileUpdated(data) => ("FileUpdated", "1", serde_json::to_value(data)?),
 
             Self::FileDeleted(data) => ("FileDeleted", "1", serde_json::to_value(data)?),
+
+            Self::FileDownloaded(data) => ("FileDownloaded", "1", serde_json::to_value(data)?),
 
             Self::FolderCreated(data) => ("FolderCreated", "1", serde_json::to_value(data)?),
 

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -214,11 +214,6 @@
         "data": {
           "type": "object",
           "properties": {
-            "createdAt": {
-              "description": "The date at which the file has been deleted",
-              "type": "string",
-              "format": "date-time"
-            },
             "fileId": {
               "type": "string"
             },
@@ -238,7 +233,6 @@
             }
           },
           "required": [
-            "createdAt",
             "fileId",
             "userId",
             "versionId",
@@ -362,11 +356,6 @@
               "description": "The workspace that the folder is in",
               "type": "string"
             },
-            "createdAt": {
-              "description": "The date at which the folder has been edited",
-              "type": "string",
-              "format": "date-time"
-            },
             "title": {
               "type": "string"
             },
@@ -379,7 +368,6 @@
             }
           },
           "required": [
-            "createdAt",
             "description",
             "userId",
             "title",

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -8,6 +8,7 @@
         { "$ref": "#/definitions/ContentViewed" },
         { "$ref": "#/definitions/FileCreated" },
         { "$ref": "#/definitions/FileUpdated" },
+        { "$ref": "#/definitions/FileDeleted" },
         { "$ref": "#/definitions/FolderCreated" },
         { "$ref": "#/definitions/WorkspaceCreated" }
       ]

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -48,9 +48,6 @@
         "data": {
           "type": "object",
           "properties": {
-            "userId": {
-              "type": "string"
-            },
             "contentId": {
               "type": "string"
             },
@@ -58,14 +55,17 @@
               "type": "string",
               "enum": ["Folder", "File"]
             },
-            "workspaceId": {
+            "error": {
               "type": "string"
             },
-            "error": {
+            "userId": {
+              "type": "string"
+            },
+            "workspaceId": {
               "type": "string"
             }
           },
-          "required": ["userId", "contentId", "contentType", "workspaceId"]
+          "required": ["contentId", "contentType", "userId", "workspaceId"]
         }
       },
       "required": ["eventType", "dataVersion", "data"]
@@ -84,20 +84,12 @@
         "data": {
           "type": "object",
           "properties": {
-            "fileId": {
-              "type": "string"
-            },
             "createdAt": {
               "description": "The date at which the file has been created",
               "type": "string",
               "format": "date-time"
             },
-            "folderId": {
-              "description": "The folder that the file is in",
-              "type": "string"
-            },
-            "workspaceId": {
-              "description": "The workspace that the file is in",
+            "fileId": {
               "type": "string"
             },
             "fileTitle": {
@@ -110,28 +102,36 @@
               "description": "The MIME type of the file, e.g. text/csv for a CSV file",
               "type": "string"
             },
+            "folderId": {
+              "description": "The folder that the file is in",
+              "type": "string"
+            },
+            "userId": {
+              "description": "The user that created the file",
+              "type": "string"
+            },
             "versionId": {
               "type": "string"
             },
             "versionNumber": {
               "type": "integer"
             },
-            "userId": {
-              "description": "The user that created the file",
+            "workspaceId": {
+              "description": "The workspace that the file is in",
               "type": "string"
             }
           },
           "required": [
-            "fileId",
             "createdAt",
-            "folderId",
-            "workspaceId",
-            "fileTitle",
             "fileDescription",
+            "fileId",
+            "fileTitle",
             "fileType",
+            "folderId",
+            "userId",
             "versionId",
             "versionNumber",
-            "userId"
+            "workspaceId"
           ]
         }
       },
@@ -154,19 +154,6 @@
             "fileId": {
               "type": "string"
             },
-            "updatedAt": {
-              "description": "The date at which the file has been updated (= the new file version has been created)",
-              "type": "string",
-              "format": "date-time"
-            },
-            "folderId": {
-              "description": "The folder that the file is in",
-              "type": "string"
-            },
-            "workspaceId": {
-              "description": "The workspace that the file is in",
-              "type": "string"
-            },
             "fileTitle": {
               "type": "string"
             },
@@ -177,28 +164,41 @@
               "description": "The MIME type of the file, e.g. text/csv for a CSV file",
               "type": "string"
             },
+            "folderId": {
+              "description": "The folder that the file is in",
+              "type": "string"
+            },
+            "updatedAt": {
+              "description": "The date at which the file has been updated (= the new file version has been created)",
+              "type": "string",
+              "format": "date-time"
+            },
+            "userId": {
+              "description": "The user that created the file",
+              "type": "string"
+            },
             "versionId": {
               "type": "string"
             },
             "versionNumber": {
               "type": "integer"
             },
-            "userId": {
-              "description": "The user that created the file",
+            "workspaceId": {
+              "description": "The workspace that the file is in",
               "type": "string"
             }
           },
           "required": [
-            "fileId",
-            "updatedAt",
-            "folderId",
-            "workspaceId",
-            "fileTitle",
             "fileDescription",
+            "fileId",
+            "fileTitle",
             "fileType",
+            "folderId",
+            "updatedAt",
+            "userId",
             "versionId",
             "versionNumber",
-            "userId"
+            "workspaceId"
           ]
         }
       },
@@ -280,7 +280,6 @@
             }
           },
           "required": [
-            "createdAt",
             "fileId",
             "userId",
             "versionId",
@@ -305,30 +304,30 @@
         "data": {
           "type": "object",
           "properties": {
-            "folderId": {
+            "description": {
               "type": "string"
             },
-            "workspaceId": {
-              "description": "The workspace that the folder is in",
+            "folderId": {
               "type": "string"
             },
             "title": {
               "type": "string"
             },
-            "description": {
-              "type": "string"
-            },
             "userId": {
               "description": "The user that created the folder",
+              "type": "string"
+            },
+            "workspaceId": {
+              "description": "The workspace that the folder is in",
               "type": "string"
             }
           },
           "required": [
             "description",
-            "userId",
+            "folderId",
             "title",
-            "workspaceId",
-            "folderId"
+            "userId",
+            "workspaceId"
           ]
         }
       },
@@ -394,16 +393,16 @@
             "folderId": {
               "type": "string"
             },
-            "workspaceId": {
-              "description": "The workspace that the folder is in",
-              "type": "string"
-            },
             "userId": {
               "description": "The user that deleted the folder",
               "type": "string"
+            },
+            "workspaceId": {
+              "description": "The workspace that the folder is in",
+              "type": "string"
             }
           },
-          "required": ["userId", "workspaceId", "folderId"]
+          "required": ["folderId", "userId", "workspaceId"]
         }
       },
       "required": ["eventType", "dataVersion", "data"]
@@ -422,18 +421,18 @@
         "data": {
           "type": "object",
           "properties": {
-            "workspaceId": {
-              "type": "string"
-            },
             "title": {
               "type": "string"
             },
             "userId": {
               "description": "The id of the user that created the workspace",
               "type": "string"
+            },
+            "workspaceId": {
+              "type": "string"
             }
           },
-          "required": ["userId", "title", "workspaceId"]
+          "required": ["title", "userId", "workspaceId"]
         }
       },
       "required": ["eventType", "dataVersion", "data"]

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -11,6 +11,7 @@
         { "$ref": "#/definitions/FileDeleted" },
         { "$ref": "#/definitions/FileDownloaded" },
         { "$ref": "#/definitions/FolderCreated" },
+        { "$ref": "#/definitions/FolderUpdated" },
         { "$ref": "#/definitions/WorkspaceCreated" }
       ]
     }
@@ -332,12 +333,12 @@
       },
       "required": ["eventType", "dataVersion", "data"]
     },
-    "FolderEdited": {
+    "FolderUpdated": {
       "type": "object",
       "properties": {
         "eventType": {
           "type": "string",
-          "enum": ["FolderEdited"]
+          "enum": ["FolderUpdated"]
         },
         "dataVersion": {
           "type": "string",
@@ -360,7 +361,7 @@
               "type": "string"
             },
             "userId": {
-              "description": "The user that edited the folder",
+              "description": "The user that updated the folder",
               "type": "string"
             }
           },

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -109,6 +109,9 @@
             "versionId": {
               "type": "string"
             },
+            "versionNumber": {
+              "type": "integer"
+            },
             "userId": {
               "description": "The user that created the file",
               "type": "string"
@@ -123,6 +126,7 @@
             "fileDescription",
             "fileType",
             "versionId",
+            "versionNumber",
             "userId"
           ]
         }
@@ -196,6 +200,104 @@
       },
       "required": ["eventType", "dataVersion", "data"]
     },
+    "FileDeleted": {
+      "type": "object",
+      "properties": {
+        "eventType": {
+          "type": "string",
+          "enum": ["FileDeleted"]
+        },
+        "dataVersion": {
+          "type": "string",
+          "enum": ["1"]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "createdAt": {
+              "description": "The date at which the file has been deleted",
+              "type": "string",
+              "format": "date-time"
+            },
+            "fileId": {
+              "type": "string"
+            },
+            "userId": {
+              "description": "The user that deleted the file",
+              "type": "string"
+            },
+            "versionId": {
+              "type": "string"
+            },
+            "versionNumber": {
+              "type": "integer"
+            },
+            "workspaceId": {
+              "description": "The workspace that the file is in",
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "fileId",
+            "userId",
+            "versionId",
+            "versionNumber",
+            "workspaceId"
+          ]
+        }
+      },
+      "required": ["eventType", "dataVersion", "data"]
+    },
+    "FileDownloaded": {
+      "type": "object",
+      "properties": {
+        "eventType": {
+          "type": "string",
+          "enum": ["FileDownloaded"]
+        },
+        "dataVersion": {
+          "type": "string",
+          "enum": ["1"]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "createdAt": {
+              "description": "The date at which the file has been downloaded",
+              "type": "string",
+              "format": "date-time"
+            },
+            "fileId": {
+              "type": "string"
+            },
+            "userId": {
+              "description": "The user that downloaded the file",
+              "type": "string"
+            },
+            "versionId": {
+              "type": "string"
+            },
+            "versionNumber": {
+              "type": "integer"
+            },
+            "workspaceId": {
+              "description": "The workspace that the file is in",
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "fileId",
+            "userId",
+            "versionId",
+            "versionNumber",
+            "workspaceId"
+          ]
+        }
+      },
+      "required": ["eventType", "dataVersion", "data"]
+    },
     "FolderCreated": {
       "type": "object",
       "properties": {
@@ -217,7 +319,15 @@
               "description": "The workspace that the folder is in",
               "type": "string"
             },
+            "createdAt": {
+              "description": "The date at which the folder has been created",
+              "type": "string",
+              "format": "date-time"
+            },
             "title": {
+              "type": "string"
+            },
+            "description": {
               "type": "string"
             },
             "userId": {
@@ -225,7 +335,63 @@
               "type": "string"
             }
           },
-          "required": ["userId", "title", "workspaceId", "folderId"]
+          "required": [
+            "createdAt",
+            "description",
+            "userId",
+            "title",
+            "workspaceId",
+            "folderId"
+          ]
+        }
+      },
+      "required": ["eventType", "dataVersion", "data"]
+    },
+    "FolderEdited": {
+      "type": "object",
+      "properties": {
+        "eventType": {
+          "type": "string",
+          "enum": ["FolderEdited"]
+        },
+        "dataVersion": {
+          "type": "string",
+          "enum": ["1"]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "folderId": {
+              "type": "string"
+            },
+            "workspaceId": {
+              "description": "The workspace that the folder is in",
+              "type": "string"
+            },
+            "createdAt": {
+              "description": "The date at which the folder has been edited",
+              "type": "string",
+              "format": "date-time"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "userId": {
+              "description": "The user that edited the folder",
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "userId",
+            "title",
+            "workspaceId",
+            "folderId"
+          ]
         }
       },
       "required": ["eventType", "dataVersion", "data"]
@@ -244,6 +410,11 @@
         "data": {
           "type": "object",
           "properties": {
+            "createdAt": {
+              "description": "The date at which the workspace has been created",
+              "type": "string",
+              "format": "date-time"
+            },
             "workspaceId": {
               "type": "string"
             },

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -12,6 +12,7 @@
         { "$ref": "#/definitions/FileDownloaded" },
         { "$ref": "#/definitions/FolderCreated" },
         { "$ref": "#/definitions/FolderUpdated" },
+        { "$ref": "#/definitions/FolderDeleted" },
         { "$ref": "#/definitions/WorkspaceCreated" }
       ]
     }
@@ -372,6 +373,37 @@
             "workspaceId",
             "folderId"
           ]
+        }
+      },
+      "required": ["eventType", "dataVersion", "data"]
+    },
+    "FolderDeleted": {
+      "type": "object",
+      "properties": {
+        "eventType": {
+          "type": "string",
+          "enum": ["FolderDeleted"]
+        },
+        "dataVersion": {
+          "type": "string",
+          "enum": ["1"]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "folderId": {
+              "type": "string"
+            },
+            "workspaceId": {
+              "description": "The workspace that the folder is in",
+              "type": "string"
+            },
+            "userId": {
+              "description": "The user that deleted the folder",
+              "type": "string"
+            }
+          },
+          "required": ["userId", "workspaceId", "folderId"]
         }
       },
       "required": ["eventType", "dataVersion", "data"]

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -9,6 +9,7 @@
         { "$ref": "#/definitions/FileCreated" },
         { "$ref": "#/definitions/FileUpdated" },
         { "$ref": "#/definitions/FileDeleted" },
+        { "$ref": "#/definitions/FileDownloaded" },
         { "$ref": "#/definitions/FolderCreated" },
         { "$ref": "#/definitions/WorkspaceCreated" }
       ]
@@ -258,11 +259,6 @@
         "data": {
           "type": "object",
           "properties": {
-            "createdAt": {
-              "description": "The date at which the file has been downloaded",
-              "type": "string",
-              "format": "date-time"
-            },
             "fileId": {
               "type": "string"
             },

--- a/event-models/schema.json
+++ b/event-models/schema.json
@@ -319,11 +319,6 @@
               "description": "The workspace that the folder is in",
               "type": "string"
             },
-            "createdAt": {
-              "description": "The date at which the folder has been created",
-              "type": "string",
-              "format": "date-time"
-            },
             "title": {
               "type": "string"
             },
@@ -336,7 +331,6 @@
             }
           },
           "required": [
-            "createdAt",
             "description",
             "userId",
             "title",
@@ -410,11 +404,6 @@
         "data": {
           "type": "object",
           "properties": {
-            "createdAt": {
-              "description": "The date at which the workspace has been created",
-              "type": "string",
-              "format": "date-time"
-            },
             "workspaceId": {
               "type": "string"
             },

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -57,6 +57,7 @@ export interface FileCreated {
      */
     fileType: string;
     versionId: string;
+    versionNumber: number;
     /**
      * The user that created the file
      */
@@ -107,7 +108,12 @@ export interface FolderCreated {
      * The workspace that the folder is in
      */
     workspaceId: string;
+    /**
+     * The date at which the folder has been created
+     */
+    createdAt: string;
     title: string;
+    description: string;
     /**
      * The user that created the folder
      */
@@ -120,6 +126,10 @@ export interface WorkspaceCreated {
   eventType: "WorkspaceCreated";
   dataVersion: "1";
   data: {
+    /**
+     * The date at which the workspace has been created
+     */
+    createdAt?: string;
     workspaceId: string;
     title: string;
     /**

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -11,6 +11,7 @@ export type Event = BaseEvent &
     | FileCreated
     | FileUpdated
     | FileDeleted
+    | FileDownloaded
     | FolderCreated
     | WorkspaceCreated
   );
@@ -107,6 +108,25 @@ export interface FileDeleted {
     fileId: string;
     /**
      * The user that deleted the file
+     */
+    userId: string;
+    versionId: string;
+    versionNumber: number;
+    /**
+     * The workspace that the file is in
+     */
+    workspaceId: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+export interface FileDownloaded {
+  eventType: "FileDownloaded";
+  dataVersion: "1";
+  data: {
+    fileId: string;
+    /**
+     * The user that downloaded the file
      */
     userId: string;
     versionId: string;

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -13,6 +13,7 @@ export type Event = BaseEvent &
     | FileDeleted
     | FileDownloaded
     | FolderCreated
+    | FolderUpdated
     | WorkspaceCreated
   );
 
@@ -152,6 +153,25 @@ export interface FolderCreated {
     description: string;
     /**
      * The user that created the folder
+     */
+    userId: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+export interface FolderUpdated {
+  eventType: "FolderUpdated";
+  dataVersion: "1";
+  data: {
+    folderId: string;
+    /**
+     * The workspace that the folder is in
+     */
+    workspaceId: string;
+    title: string;
+    description: string;
+    /**
+     * The user that updated the folder
      */
     userId: string;
     [k: string]: unknown;

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -108,10 +108,6 @@ export interface FolderCreated {
      * The workspace that the folder is in
      */
     workspaceId: string;
-    /**
-     * The date at which the folder has been created
-     */
-    createdAt: string;
     title: string;
     description: string;
     /**
@@ -126,10 +122,6 @@ export interface WorkspaceCreated {
   eventType: "WorkspaceCreated";
   dataVersion: "1";
   data: {
-    /**
-     * The date at which the workspace has been created
-     */
-    createdAt?: string;
     workspaceId: string;
     title: string;
     /**

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -28,11 +28,11 @@ export interface ContentViewed {
   eventType: "ContentViewed";
   dataVersion: "1";
   data: {
-    userId: string;
     contentId: string;
     contentType: "Folder" | "File";
-    workspaceId: string;
     error?: string;
+    userId: string;
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;
@@ -41,31 +41,31 @@ export interface FileCreated {
   eventType: "FileCreated";
   dataVersion: "1";
   data: {
-    fileId: string;
     /**
      * The date at which the file has been created
      */
     createdAt: string;
-    /**
-     * The folder that the file is in
-     */
-    folderId: string;
-    /**
-     * The workspace that the file is in
-     */
-    workspaceId: string;
+    fileId: string;
     fileTitle: string;
     fileDescription: string;
     /**
      * The MIME type of the file, e.g. text/csv for a CSV file
      */
     fileType: string;
-    versionId: string;
-    versionNumber: number;
+    /**
+     * The folder that the file is in
+     */
+    folderId: string;
     /**
      * The user that created the file
      */
     userId: string;
+    versionId: string;
+    versionNumber: number;
+    /**
+     * The workspace that the file is in
+     */
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;
@@ -75,30 +75,30 @@ export interface FileUpdated {
   dataVersion: "1";
   data: {
     fileId: string;
-    /**
-     * The date at which the file has been updated (= the new file version has been created)
-     */
-    updatedAt: string;
-    /**
-     * The folder that the file is in
-     */
-    folderId: string;
-    /**
-     * The workspace that the file is in
-     */
-    workspaceId: string;
     fileTitle: string;
     fileDescription: string;
     /**
      * The MIME type of the file, e.g. text/csv for a CSV file
      */
     fileType: string;
-    versionId: string;
-    versionNumber: number;
+    /**
+     * The folder that the file is in
+     */
+    folderId: string;
+    /**
+     * The date at which the file has been updated (= the new file version has been created)
+     */
+    updatedAt: string;
     /**
      * The user that created the file
      */
     userId: string;
+    versionId: string;
+    versionNumber: number;
+    /**
+     * The workspace that the file is in
+     */
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;
@@ -145,17 +145,17 @@ export interface FolderCreated {
   eventType: "FolderCreated";
   dataVersion: "1";
   data: {
-    folderId: string;
-    /**
-     * The workspace that the folder is in
-     */
-    workspaceId: string;
-    title: string;
     description: string;
+    folderId: string;
+    title: string;
     /**
      * The user that created the folder
      */
     userId: string;
+    /**
+     * The workspace that the folder is in
+     */
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;
@@ -185,13 +185,13 @@ export interface FolderDeleted {
   data: {
     folderId: string;
     /**
-     * The workspace that the folder is in
-     */
-    workspaceId: string;
-    /**
      * The user that deleted the folder
      */
     userId: string;
+    /**
+     * The workspace that the folder is in
+     */
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;
@@ -200,12 +200,12 @@ export interface WorkspaceCreated {
   eventType: "WorkspaceCreated";
   dataVersion: "1";
   data: {
-    workspaceId: string;
     title: string;
     /**
      * The id of the user that created the workspace
      */
     userId: string;
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -10,6 +10,7 @@ export type Event = BaseEvent &
     | ContentViewed
     | FileCreated
     | FileUpdated
+    | FileDeleted
     | FolderCreated
     | WorkspaceCreated
   );
@@ -95,6 +96,25 @@ export interface FileUpdated {
      * The user that created the file
      */
     userId: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+export interface FileDeleted {
+  eventType: "FileDeleted";
+  dataVersion: "1";
+  data: {
+    fileId: string;
+    /**
+     * The user that deleted the file
+     */
+    userId: string;
+    versionId: string;
+    versionNumber: number;
+    /**
+     * The workspace that the file is in
+     */
+    workspaceId: string;
     [k: string]: unknown;
   };
   [k: string]: unknown;

--- a/event-models/typescript/src/schema.ts
+++ b/event-models/typescript/src/schema.ts
@@ -14,6 +14,7 @@ export type Event = BaseEvent &
     | FileDownloaded
     | FolderCreated
     | FolderUpdated
+    | FolderDeleted
     | WorkspaceCreated
   );
 
@@ -172,6 +173,23 @@ export interface FolderUpdated {
     description: string;
     /**
      * The user that updated the folder
+     */
+    userId: string;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+export interface FolderDeleted {
+  eventType: "FolderDeleted";
+  dataVersion: "1";
+  data: {
+    folderId: string;
+    /**
+     * The workspace that the folder is in
+     */
+    workspaceId: string;
+    /**
+     * The user that deleted the folder
      */
     userId: string;
     [k: string]: unknown;

--- a/workspace-service/src/graphql/file_download_urls.rs
+++ b/workspace-service/src/graphql/file_download_urls.rs
@@ -15,7 +15,7 @@ impl FileDownloadUrlsMutation {
         let pool = context.data()?;
         let config = context.data()?;
         let event_client: &EventClient = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
+        let requesting_user: &super::RequestingUser = context.data()?;
         let user = db::UserRepo::find_by_auth_id(&requesting_user.auth_id, pool).await?;
         let id = Uuid::parse_str(&id)?;
         let file = db::FileWithVersionRepo::find_by_id(id, pool).await?;

--- a/workspace-service/src/graphql/file_download_urls.rs
+++ b/workspace-service/src/graphql/file_download_urls.rs
@@ -1,6 +1,7 @@
 use super::azure;
 use super::db;
 use async_graphql::{Context, FieldResult, Object, ID};
+use fnhs_event_models::{Event, EventClient, EventPublisher as _, FileDownloadedData};
 use url::Url;
 use uuid::Uuid;
 
@@ -13,8 +14,25 @@ impl FileDownloadUrlsMutation {
     async fn file_download_url(&self, context: &Context<'_>, id: ID) -> FieldResult<Url> {
         let pool = context.data()?;
         let config = context.data()?;
+        let event_client: &EventClient = context.data()?;
+        let requesting_user = context.data::<super::RequestingUser>()?;
+        let user = db::UserRepo::find_by_auth_id(&requesting_user.auth_id, pool).await?;
         let id = Uuid::parse_str(&id)?;
         let file = db::FileWithVersionRepo::find_by_id(id, pool).await?;
+        let folder = db::FolderRepo::find_by_id(file.folder, pool).await?;
+
+        event_client
+            .publish_events(&[Event::new(
+                id.to_string(),
+                FileDownloadedData {
+                    file_id: file.id.to_string(),
+                    user_id: user.id.to_string(),
+                    version_number: file.version_number.into(),
+                    version_id: file.version.to_string(),
+                    workspace_id: folder.workspace.to_string(),
+                },
+            )])
+            .await?;
 
         Ok(azure::create_download_sas(
             config,

--- a/workspace-service/src/graphql/file_download_urls.rs
+++ b/workspace-service/src/graphql/file_download_urls.rs
@@ -2,6 +2,7 @@ use super::azure;
 use super::db;
 use async_graphql::{Context, FieldResult, Object, ID};
 use fnhs_event_models::{Event, EventClient, EventPublisher as _, FileDownloadedData};
+use sqlx::PgPool;
 use url::Url;
 use uuid::Uuid;
 
@@ -14,29 +15,70 @@ impl FileDownloadUrlsMutation {
     async fn file_download_url(&self, context: &Context<'_>, id: ID) -> FieldResult<Url> {
         let pool = context.data()?;
         let config = context.data()?;
-        let event_client: &EventClient = context.data()?;
-        let requesting_user: &super::RequestingUser = context.data()?;
-        let user = db::UserRepo::find_by_auth_id(&requesting_user.auth_id, pool).await?;
-        let id = Uuid::parse_str(&id)?;
-        let file = db::FileWithVersionRepo::find_by_id(id, pool).await?;
-        let folder = db::FolderRepo::find_by_id(file.folder, pool).await?;
+        let event_client = context.data()?;
+        let requesting_user = context.data()?;
 
-        event_client
-            .publish_events(&[Event::new(
-                id.to_string(),
-                FileDownloadedData {
-                    file_id: file.id.to_string(),
-                    user_id: user.id.to_string(),
-                    version_number: file.version_number.into(),
-                    version_id: file.version.to_string(),
-                    workspace_id: folder.workspace.to_string(),
-                },
-            )])
-            .await?;
+        file_download_url(id, pool, config, event_client, requesting_user).await
+    }
+}
 
-        Ok(azure::create_download_sas(
-            config,
-            &file.blob_storage_path.parse()?,
-        )?)
+async fn file_download_url(
+    id: ID,
+    pool: &PgPool,
+    config: &azure::Config,
+    event_client: &EventClient,
+    requesting_user: &super::RequestingUser,
+) -> FieldResult<Url> {
+    let user = db::UserRepo::find_by_auth_id(&requesting_user.auth_id, pool).await?;
+    let id = Uuid::parse_str(&id)?;
+    let file = db::FileWithVersionRepo::find_by_id(id, pool).await?;
+    let folder = db::FolderRepo::find_by_id(file.folder, pool).await?;
+
+    event_client
+        .publish_events(&[Event::new(
+            id.to_string(),
+            FileDownloadedData {
+                file_id: file.id.to_string(),
+                user_id: user.id.to_string(),
+                version_number: file.version_number.into(),
+                version_id: file.version.to_string(),
+                workspace_id: folder.workspace.to_string(),
+            },
+        )])
+        .await?;
+
+    Ok(azure::create_download_sas(
+        config,
+        &file.blob_storage_path.parse()?,
+    )?)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::graphql::test_mocks::*;
+    use fnhs_event_models::EventData;
+    #[async_std::test]
+    async fn file_download_url_emits_event() -> anyhow::Result<()> {
+        let pool = mock_connection_pool()?;
+        let azure_config = mock_azure_config()?;
+        let requesting_user = mock_unprivileged_requesting_user();
+        let (events, event_client) = mock_event_emitter();
+
+        file_download_url(
+            "1f20fa4c-543c-45b4-93bb-a6e21a8e4de5".into(),
+            &pool,
+            &azure_config,
+            &event_client,
+            &requesting_user,
+        )
+        .await
+        .unwrap();
+
+        assert!(events
+            .try_iter()
+            .any(|e| matches!(e.data, EventData::FileDownloaded(_))));
+
+        Ok(())
     }
 }

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -535,7 +535,10 @@ mod test {
 
         let result = delete_file(id, &pool, &requesting_user, &event_client).await;
 
-        assert_eq!(result.unwrap().id, ID::from("96bb1f76-6d0e-4a14-a379-034a738715ec"));
+        assert_eq!(
+            result.unwrap().id,
+            ID::from("96bb1f76-6d0e-4a14-a379-034a738715ec")
+        );
         assert!(events
             .try_iter()
             .any(|e| matches!(e.data, EventData::FileDeleted(_))));

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -209,8 +209,8 @@ impl FilesMutation {
     async fn create_file(&self, context: &Context<'_>, new_file: NewFile) -> FieldResult<File> {
         let pool = context.data()?;
         let azure_config = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
-        let event_client: &EventClient = context.data()?;
+        let requesting_user = context.data()?;
+        let event_client = context.data()?;
 
         create_file(new_file, pool, azure_config, requesting_user, event_client).await
     }
@@ -229,8 +229,8 @@ impl FilesMutation {
     ) -> FieldResult<File> {
         let pool = context.data()?;
         let azure_config = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
-        let event_client: &EventClient = context.data()?;
+        let requesting_user = context.data()?;
+        let event_client = context.data()?;
 
         create_file_version(
             new_version,
@@ -245,8 +245,8 @@ impl FilesMutation {
     /// Deletes a file by id(returns delete file
     async fn delete_file(&self, context: &Context<'_>, id: ID) -> FieldResult<File> {
         let pool = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
-        let event_client: &EventClient = context.data()?;
+        let requesting_user = context.data()?;
+        let event_client = context.data()?;
 
         delete_file(id, pool, requesting_user, event_client).await
     }

--- a/workspace-service/src/graphql/files.rs
+++ b/workspace-service/src/graphql/files.rs
@@ -304,6 +304,7 @@ async fn create_file(
                 user_id: user.id.to_string(),
                 workspace_id: folder.workspace.to_string(),
                 version_id: file.latest_version.to_string(),
+                version_number: 1,
             },
         )])
         .await?;

--- a/workspace-service/src/graphql/folders.rs
+++ b/workspace-service/src/graphql/folders.rs
@@ -87,8 +87,8 @@ impl FoldersMutation {
     ) -> FieldResult<Folder> {
         let pool = context.data()?;
         let workspace = Uuid::parse_str(&new_folder.workspace)?;
-        let event_client: &EventClient = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
+        let event_client = context.data()?;
+        let requesting_user = context.data()?;
 
         create_folder(
             &new_folder.title,
@@ -109,8 +109,8 @@ impl FoldersMutation {
         folder: UpdateFolder,
     ) -> FieldResult<Folder> {
         let pool = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
-        let event_client: &EventClient = context.data()?;
+        let requesting_user = context.data()?;
+        let event_client = context.data()?;
 
         update_folder(
             id,
@@ -125,10 +125,9 @@ impl FoldersMutation {
 
     /// Delete folder (returns deleted folder
     async fn delete_folder(&self, context: &Context<'_>, id: ID) -> FieldResult<Folder> {
-        // TODO: Add event
         let pool = context.data()?;
-        let requesting_user = context.data::<super::RequestingUser>()?;
-        let event_client: &EventClient = context.data()?;
+        let requesting_user = context.data()?;
+        let event_client = context.data()?;
 
         delete_folder(id, pool, requesting_user, event_client).await
     }

--- a/workspace-service/src/graphql/folders.rs
+++ b/workspace-service/src/graphql/folders.rs
@@ -147,6 +147,7 @@ async fn create_folder(
                 // TODO: Fill this in when we have users in the db.
                 user_id: "".into(),
                 title: folder.title.clone(),
+                description: folder.description.clone(),
             },
         )])
         .await?;

--- a/workspace-service/src/graphql/folders.rs
+++ b/workspace-service/src/graphql/folders.rs
@@ -1,6 +1,8 @@
 use super::{db, RequestingUser};
 use async_graphql::{Context, FieldResult, InputObject, Object, SimpleObject, ID};
-use fnhs_event_models::{Event, EventClient, EventPublisher, FolderCreatedData, FolderUpdatedData};
+use fnhs_event_models::{
+    Event, EventClient, EventPublisher, FolderCreatedData, FolderDeletedData, FolderUpdatedData,
+};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -125,9 +127,10 @@ impl FoldersMutation {
     async fn delete_folder(&self, context: &Context<'_>, id: ID) -> FieldResult<Folder> {
         // TODO: Add event
         let pool = context.data()?;
-        let folder = db::FolderRepo::delete(Uuid::parse_str(&id)?, pool).await?;
+        let requesting_user = context.data::<super::RequestingUser>()?;
+        let event_client: &EventClient = context.data()?;
 
-        Ok(folder.into())
+        delete_folder(id, pool, requesting_user, event_client).await
     }
 }
 
@@ -188,11 +191,55 @@ async fn update_folder(
     Ok(folder.into())
 }
 
+async fn delete_folder(
+    id: ID,
+    pool: &PgPool,
+    requesting_user: &RequestingUser,
+    event_client: &EventClient,
+) -> FieldResult<Folder> {
+    let folder = db::FolderRepo::delete(Uuid::parse_str(&id)?, pool).await?;
+    let user = db::UserRepo::find_by_auth_id(&requesting_user.auth_id, pool).await?;
+    event_client
+        .publish_events(&[Event::new(
+            id,
+            FolderDeletedData {
+                folder_id: folder.id.to_string(),
+                user_id: user.id.to_string(),
+                workspace_id: folder.workspace.to_string(),
+            },
+        )])
+        .await?;
+    Ok(folder.into())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::graphql::test_mocks::*;
     use fnhs_event_models::EventData;
+
+    #[async_std::test]
+    async fn deleting_folder_emits_an_event() -> anyhow::Result<()> {
+        let pool = mock_connection_pool()?;
+        let (events, event_client) = mock_event_emitter();
+        let requesting_user = mock_unprivileged_requesting_user();
+
+        let folder = delete_folder(
+            "d890181d-6b17-428e-896b-f76add15b54a".into(),
+            &pool,
+            &requesting_user,
+            &event_client,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(folder.id, "d890181d-6b17-428e-896b-f76add15b54a");
+        assert!(events
+            .try_iter()
+            .any(|e| matches!(e.data, EventData::FolderDeleted(_))));
+
+        Ok(())
+    }
 
     #[async_std::test]
     async fn creating_folder_emits_an_event() -> anyhow::Result<()> {

--- a/workspace-service/src/graphql/test_mocks.rs
+++ b/workspace-service/src/graphql/test_mocks.rs
@@ -36,7 +36,8 @@ pub fn mock_unprivileged_requesting_user() -> RequestingUser {
 
 pub fn mock_azure_config() -> anyhow::Result<azure::Config> {
     azure::Config::new(
-        "fake key".into(),
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+            .into(),
         Url::parse("http://localhost:10000/devstoreaccount1/upload")?,
         Url::parse("http://localhost:10000/devstoreaccount1/files")?,
     )


### PR DESCRIPTION
![](https://media.giphy.com/media/PP7RblbpOHAHu/giphy.gif)

[Ticket](https://dev.azure.com/futurenhs/FutureNHS/_boards/board/t/FutureNHS%20Team/Stories/?workitem=2245)


## Acceptance Criteria
This PR adds analytics events in where they don't exist already (generally due to workspace service functionality being created before events were up and running), as well as modifying some existing events with extra fields.

Existing events modified in this PR:
- [x] FileCreated - add 'versionNumber'
- [x] FolderCreated - add 'description'

New events added in this PR:
 - [x] FileDeleted
 - [x] FileDownload
 - [x] FolderUpdated
- [x] FolderDeleted

## Pre-review checklist:

- [ ] Tests

- [ ] Documentation

- [ ] Analytics (user analytics, e.g. Google Analytics)

- [ ] Observability (metrics/tracing)

- [ ] Feature flag

- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?

- Test plan?

Backend only - Jamie to discuss with Declan about how to incorporate events into the QA process.
