### PR TITLE
make workspace.members take an argument

### DIFF
--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -362,6 +362,29 @@
       },
       {
         "description": null,
+        "enumValues": [
+          {
+            "deprecationReason": null,
+            "description": "Only return Admins",
+            "isDeprecated": false,
+            "name": "ADMINS_ONLY"
+          },
+          {
+            "deprecationReason": null,
+            "description": "Only return Non-Admins",
+            "isDeprecated": false,
+            "name": "WITHOUT_ADMINS"
+          }
+        ],
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "kind": "ENUM",
+        "name": "MemberFilter",
+        "possibleTypes": null
+      },
+      {
+        "description": null,
         "enumValues": null,
         "fields": [
           {
@@ -1719,7 +1742,18 @@
             }
           },
           {
-            "args": [],
+            "args": [
+              {
+                "defaultValue": null,
+                "description": null,
+                "name": "filter",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "MemberFilter",
+                  "ofType": null
+                }
+              }
+            ],
             "deprecationReason": null,
             "description": "List of all users who are members of this workspace",
             "isDeprecated": false,

--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -362,29 +362,6 @@
       },
       {
         "description": null,
-        "enumValues": [
-          {
-            "deprecationReason": null,
-            "description": "Only return Admins",
-            "isDeprecated": false,
-            "name": "ADMINS_ONLY"
-          },
-          {
-            "deprecationReason": null,
-            "description": "Only return Non-Admins",
-            "isDeprecated": false,
-            "name": "WITHOUT_ADMINS"
-          }
-        ],
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "kind": "ENUM",
-        "name": "MemberFilter",
-        "possibleTypes": null
-      },
-      {
-        "description": null,
         "enumValues": null,
         "fields": [
           {
@@ -1438,6 +1415,29 @@
         "possibleTypes": null
       },
       {
+        "description": null,
+        "enumValues": [
+          {
+            "deprecationReason": null,
+            "description": "Only return Admins",
+            "isDeprecated": false,
+            "name": "ADMIN"
+          },
+          {
+            "deprecationReason": null,
+            "description": "Only return Non-Admins",
+            "isDeprecated": false,
+            "name": "NON_ADMIN"
+          }
+        ],
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "kind": "ENUM",
+        "name": "RoleFilter",
+        "possibleTypes": null
+      },
+      {
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
         "enumValues": null,
         "fields": null,
@@ -1725,7 +1725,7 @@
                 "name": "filter",
                 "type": {
                   "kind": "ENUM",
-                  "name": "MemberFilter",
+                  "name": "RoleFilter",
                   "ofType": null
                 }
               }

--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -1718,30 +1718,6 @@
             }
           },
           {
-            "args": [],
-            "deprecationReason": null,
-            "description": "List of users in the admin team",
-            "isDeprecated": false,
-            "name": "admins",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "User",
-                    "ofType": null
-                  }
-                }
-              }
-            }
-          },
-          {
             "args": [
               {
                 "defaultValue": null,
@@ -1755,7 +1731,7 @@
               }
             ],
             "deprecationReason": null,
-            "description": "List of all users who are members of this workspace",
+            "description": "List of users who are members of this workspace.\n\nPass filter: ADMINS_ONLY or WITHOUT_ADMINS for finer control over\nwhich members are returned.",
             "isDeprecated": false,
             "name": "members",
             "type": {

--- a/workspace-service/sql/teams/members.sql
+++ b/workspace-service/sql/teams/members.sql
@@ -5,3 +5,5 @@ FROM
 	JOIN link_users_teams ON users.id = link_users_teams.user_id
 WHERE
 	link_users_teams.team_id = $1
+ORDER BY
+	users.name

--- a/workspace-service/sql/teams/members_difference.sql
+++ b/workspace-service/sql/teams/members_difference.sql
@@ -8,3 +8,5 @@ SELECT
 FROM
 	users
 	JOIN user_ids ON users.id = user_ids.user_id
+ORDER BY
+	users.name

--- a/workspace-service/sql/teams/members_difference.sql
+++ b/workspace-service/sql/teams/members_difference.sql
@@ -1,0 +1,10 @@
+WITH user_ids as (
+    SELECT user_id FROM link_users_teams WHERE team_id = $1
+    EXCEPT
+    SELECT user_id FROM link_users_teams WHERE team_id = $2
+)
+SELECT
+	users.*
+FROM
+	users
+	JOIN user_ids ON users.id = user_ids.user_id

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -42,6 +42,50 @@
       ]
     }
   },
+  "0d37e1a94f7fbbfa6758722565300aff5430e6ea9fc1fe8b4060bf5befc7e3d7": {
+    "query": "SELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN link_users_teams ON users.id = link_users_teams.user_id\nWHERE\n\tlink_users_teams.team_id = $1\nORDER BY\n\tusers.name\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "auth_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_platform_admin",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "email_address",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "12fa7fc1483550592cb56dc2b229c19546632bdb6d005ffcf1d312adc611c077": {
     "query": "INSERT INTO workspaces (title, description, admins, members)\nVALUES ($1, $2, $3, $4)\nRETURNING *\n",
     "describe": {
@@ -272,50 +316,6 @@
         ]
       },
       "nullable": [
-        false,
-        false
-      ]
-    }
-  },
-  "30ca906859817bb8fe8e85b4029315fa6366ab50ce91b0ed0bf36c48ebd788e9": {
-    "query": "SELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN link_users_teams ON users.id = link_users_teams.user_id\nWHERE\n\tlink_users_teams.team_id = $1\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "auth_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "is_platform_admin",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 4,
-          "name": "email_address",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
         false,
         false
       ]
@@ -638,8 +638,8 @@
       ]
     }
   },
-  "7aad6ccc9ad6fe5b20bddb1ac668cebaa026842c880daefd73cd25ff931143a7": {
-    "query": "WITH user_ids as (\n    SELECT user_id FROM link_users_teams WHERE team_id = $1\n    EXCEPT\n    SELECT user_id FROM link_users_teams WHERE team_id = $2\n)\nSELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN user_ids ON users.id = user_ids.user_id\n",
+  "7c2eb4c370b448dcaab3585cf7a3526df946c1e8677bd80bb8eaeb8938528a85": {
+    "query": "WITH user_ids as (\n    SELECT user_id FROM link_users_teams WHERE team_id = $1\n    EXCEPT\n    SELECT user_id FROM link_users_teams WHERE team_id = $2\n)\nSELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN user_ids ON users.id = user_ids.user_id\nORDER BY\n\tusers.name\n",
     "describe": {
       "columns": [
         {

--- a/workspace-service/sqlx-data.json
+++ b/workspace-service/sqlx-data.json
@@ -638,6 +638,51 @@
       ]
     }
   },
+  "7aad6ccc9ad6fe5b20bddb1ac668cebaa026842c880daefd73cd25ff931143a7": {
+    "query": "WITH user_ids as (\n    SELECT user_id FROM link_users_teams WHERE team_id = $1\n    EXCEPT\n    SELECT user_id FROM link_users_teams WHERE team_id = $2\n)\nSELECT\n\tusers.*\nFROM\n\tusers\n\tJOIN user_ids ON users.id = user_ids.user_id\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 1,
+          "name": "auth_id",
+          "type_info": "Uuid"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "is_platform_admin",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "email_address",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "93c4976d0825c426eec25dd14c201e8ba4bbf4df8fa17280c583cf20f3dbbe64": {
     "query": "DELETE FROM workspaces\nWHERE id = $1\nRETURNING *\n",
     "describe": {

--- a/workspace-service/src/db/teams.rs
+++ b/workspace-service/src/db/teams.rs
@@ -27,11 +27,23 @@ impl TeamRepo {
 
         Ok(group)
     }
+
     pub async fn members<'c, E>(id: Uuid, executor: E) -> Result<Vec<User>>
     where
         E: Executor<'c, Database = Postgres>,
     {
         let users = sqlx::query_file_as!(User, "sql/teams/members.sql", id)
+            .fetch_all(executor)
+            .await?;
+
+        Ok(users)
+    }
+
+    pub async fn members_difference<'c, E>(id_a: Uuid, id_b: Uuid, executor: E) -> Result<Vec<User>>
+    where
+        E: Executor<'c, Database = Postgres>,
+    {
+        let users = sqlx::query_file_as!(User, "sql/teams/members_difference.sql", id_a, id_b)
             .fetch_all(executor)
             .await?;
 
@@ -63,6 +75,18 @@ impl TeamRepoFake {
         E: Executor<'c, Database = Postgres>,
     {
         let users = vec![crate::db::UserRepo::find_by_auth_id(&id, executor).await?];
+
+        Ok(users)
+    }
+    pub async fn members_difference<'c, E>(
+        id_a: Uuid,
+        _id_b: Uuid,
+        executor: E,
+    ) -> Result<Vec<User>>
+    where
+        E: Executor<'c, Database = Postgres>,
+    {
+        let users = vec![crate::db::UserRepo::find_by_auth_id(&id_a, executor).await?];
 
         Ok(users)
     }

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -38,14 +38,10 @@ impl Workspace {
         self.description.clone()
     }
 
-    /// List of users in the admin team
-    async fn admins(&self, context: &Context<'_>) -> FieldResult<Vec<User>> {
-        let pool = context.data()?;
-        let users = db::TeamRepo::members(self.admins, pool).await?;
-        Ok(users.into_iter().map(Into::into).collect())
-    }
-
-    /// List of all users who are members of this workspace
+    /// List of users who are members of this workspace.
+    ///
+    /// Pass filter: ADMINS_ONLY or WITHOUT_ADMINS for finer control over
+    /// which members are returned.
     async fn members(
         &self,
         context: &Context<'_>,

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -15,11 +15,11 @@ pub struct Workspace {
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
-pub enum MemberFilter {
+pub enum RoleFilter {
     /// Only return Admins
-    AdminsOnly,
+    Admin,
     /// Only return Non-Admins
-    WithoutAdmins,
+    NonAdmin,
 }
 
 #[Object]
@@ -45,12 +45,12 @@ impl Workspace {
     async fn members(
         &self,
         context: &Context<'_>,
-        filter: Option<MemberFilter>,
+        filter: Option<RoleFilter>,
     ) -> FieldResult<Vec<User>> {
         let pool = context.data()?;
         let users = match filter {
-            Some(MemberFilter::AdminsOnly) => db::TeamRepo::members(self.admins, pool).await?,
-            Some(MemberFilter::WithoutAdmins) => {
+            Some(RoleFilter::Admin) => db::TeamRepo::members(self.admins, pool).await?,
+            Some(RoleFilter::NonAdmin) => {
                 db::TeamRepo::members_difference(self.members, self.admins, pool).await?
             }
             None => db::TeamRepo::members(self.members, pool).await?,


### PR DESCRIPTION
Use it like this:
```
query {
  workspaces {
    title,
    admins: members(filter: ADMINS_ONLY) {name}
    members(filter: WITHOUT_ADMINS) {name}
  }
}
```

Part of [AB#2072](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/2072)


## Acceptance Criteria

The requirement on the ticket is to exclude admins from the Members list in the UI

## Pre-review checklist:

- [ ] Tests - We should work out a nice way to handle this in the stub server?

## Testing information

- Is there any special setup required? No. Example workspace already has teams for Admins and Members.

## Test:

- [ ] Tested locally


![](https://media.giphy.com/media/vSJyRUtORbQC4/giphy-downsized.gif)