### PR TITLE
[Bug 2259] Change z-index on 'options' Tooltip and MenuList

### DIFF
--- a/frontend/components/Menu/MenuList.tsx
+++ b/frontend/components/Menu/MenuList.tsx
@@ -7,7 +7,7 @@ import { MenuListItem } from ".";
 import { MenuItem } from "./MenuListItem";
 
 const Container = styled.div`
-  z-index: 1000;
+  z-index: 10;
   width: 320px;
   border-radius: 4px;
 

--- a/frontend/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/frontend/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Menu takes a snapshot, as used in a page 1`] = `
 .c5 {
   opacity: 0;
   position: absolute;
-  z-index: 2000;
+  z-index: 5;
   border-radius: 4px;
   background-color: rgb(76,98,114);
   padding: 5px;
@@ -177,7 +177,7 @@ exports[`Menu takes a snapshot, as used in the nav 1`] = `
 .c5 {
   opacity: 0;
   position: absolute;
-  z-index: 2000;
+  z-index: 5;
   border-radius: 4px;
   background-color: rgb(76,98,114);
   padding: 5px;

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<Navigation/> renders correctly 1`] = `
 .c14 {
   opacity: 0;
   position: absolute;
-  z-index: 2000;
+  z-index: 5;
   border-radius: 4px;
   background-color: rgb(76,98,114);
   padding: 5px;

--- a/frontend/components/Tooltip/Tooltip.tsx
+++ b/frontend/components/Tooltip/Tooltip.tsx
@@ -18,7 +18,7 @@ const Inner = styled.span`
   }
   opacity: 0;
   position: absolute;
-  z-index: 2000;
+  z-index: 5;
   border-radius: 4px;
   background-color: ${({ theme }) => theme.colorNhsukGrey1};
   padding: 5px;


### PR DESCRIPTION
<img src="https://media.giphy.com/media/l4Jza5P4cMcCTHoGs/giphy.gif" />

[2259 [Folder Navigation] Meatball menu "options" tooltips can interfere with clicking on items in the options menu](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2259)

Fixes #343 

## Acceptance Criteria
- [x] The options tooltip should appear under the menu so it doesn't interfere with menu interaction.

## Pre-review checklist:

- [x] Tests

~~- [ ] Documentation~~

~~- [ ] Analytics (user analytics, e.g. Google Analytics)~~

~~- [ ] Observability (metrics/tracing)~~

~~- [ ] Feature flag~~

~~- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)~~

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [x] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
