### PR TITLE
Bug 2258 - Add hover/focus/active states to Workspace title in folder nav

### DIFF
--- a/frontend/components/Navigation/Navigation.tsx
+++ b/frontend/components/Navigation/Navigation.tsx
@@ -32,16 +32,29 @@ const Header = styled.header`
 
 const WorkspaceTitleLink = styled.a`
   text-decoration: none;
-  color: inherit;
-
-  &:hover {
-    color: inherit;
+  h3 {
+    width: fit-content;
+    margin-bottom: 8px;
+    border-bottom: 4px solid transparent;
+    ${({ theme }) => `
+      color: ${theme.colorNhsukBlue};
+    `}
+  }
+  &:focus > h3 {
+    ${({ theme }) => `
+      color: ${theme.colorNhsukBlack};
+      background-color: ${theme.colorNhsukYellow};
+      border-bottom: 4px solid ${theme.colorNhsukBlack};
+    `}
+  }
+  &:hover:not(:focus) > h3 {
+    ${({ theme }) => `
+      color: ${theme.colorNhsukPurple};
+      text-decoration: underline;
+    `}
   }
   &:visited {
     color: inherit;
-  }
-  h3 {
-    margin-bottom: 12px;
   }
 `;
 
@@ -65,6 +78,19 @@ const LinkList = styled.ul`
 const LinkListItem = styled.li`
   list-style-type: none;
   font-size: 16px;
+
+  a {
+    :hover:not(:focus) {
+      ${({ theme }) => `
+        color: ${theme.colorNhsukPurple};
+        text-decoration: underline;
+      `}
+    }
+    ${({ theme }) => `
+      text-decoration: none;
+      color: ${theme.colorNhsukBlue}
+    `}
+  }
 `;
 
 interface Props {

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -239,19 +239,31 @@ exports[`<Navigation/> renders correctly 1`] = `
 .c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: inherit;
 }
 
-.c2:hover {
-  color: inherit;
+.c2 h3 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-bottom: 8px;
+  border-bottom: 4px solid transparent;
+  color: rgb(0,94,184);
+}
+
+.c2:focus > h3 {
+  color: rgb(33,43,50);
+  background-color: rgb(255,235,59);
+  border-bottom: 4px solid rgb(33,43,50);
+}
+
+.c2:hover:not(:focus) > h3 {
+  color: rgb(51,0,114);
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c2:visited {
   color: inherit;
-}
-
-.c2 h3 {
-  margin-bottom: 12px;
 }
 
 .c6 {
@@ -272,6 +284,18 @@ exports[`<Navigation/> renders correctly 1`] = `
 .c4 {
   list-style-type: none;
   font-size: 16px;
+}
+
+.c4 a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: rgb(0,94,184);
+}
+
+.c4 a:hover:not(:focus) {
+  color: rgb(51,0,114);
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 @media (min-width:990px) {


### PR DESCRIPTION
<img src="https://media.giphy.com/media/kyQiCZuymIOvKavFxt/giphy.gif" />

[2258 [Folder Navigation] Workspace name in folder nav doesn't have hover/focus/active states](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2258)

In addition to adding hover/focus/active states to the Workspace title, at Kim's request I changed the colour of the title and links to blue and changed the underline behaviour. 

## Acceptance Criteria
- [x] The workspace title should have the appropriate hover/focus/active states.
- [x] Change colour of title/links to be blue, :hover to be underlined and purple

## Pre-review checklist:

- [x] Tests

- [ ] Documentation

- [ ] Analytics (user analytics, e.g. Google Analytics)

- [ ] Observability (metrics/tracing)

- [ ] Feature flag

- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
