### PR TITLE
[Bug 2253] Fix clashing hover/active states on Workspace Directory Items

### DIFF
--- a/frontend/components/Workspaces/WorkspaceDirectoryItem.tsx
+++ b/frontend/components/Workspaces/WorkspaceDirectoryItem.tsx
@@ -25,10 +25,8 @@ const StyledLink = styled.a`
   }
 
   &:active {
-    ${({ theme }) => `
-        color: ${theme.colorNhsukBlack};
-        background-color: ${theme.colorNhsukYellow};
-      `}
+    color: ${({ theme }) => theme.colorNhsukBlack};
+    background-color: ${({ theme }) => theme.colorNhsukYellow};
     text-decoration: none;
   }
 

--- a/frontend/components/Workspaces/WorkspaceDirectoryItem.tsx
+++ b/frontend/components/Workspaces/WorkspaceDirectoryItem.tsx
@@ -16,27 +16,27 @@ const StyledContainer = styled.div`
 `;
 
 const StyledLink = styled.a`
-  ${({ theme }) => `
   display: flex;
   text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  &:active {
+    ${({ theme }) => `
+        color: ${theme.colorNhsukBlack};
+        background-color: ${theme.colorNhsukYellow};
+      `}
+    text-decoration: none;
+  }
 
   div {
     margin-bottom: 0px;
     font-size: 22px;
     font-weight: 600;
-
-    &:hover {
-      text-decoration: underline;
-      cursor: pointer;
-      }
-
-    &:active {
-      color: ${theme.colorNhsukBlack};
-      text-decoration: none;
-      background-color: ${theme.colorNhsukYellow};
-      }
-    }
- `}
+  }
 `;
 
 interface Props {

--- a/frontend/components/Workspaces/__snapshots__/WorkspaceDirectoryItem.test.tsx.snap
+++ b/frontend/components/Workspaces/__snapshots__/WorkspaceDirectoryItem.test.tsx.snap
@@ -30,23 +30,23 @@ exports[`snapshot of component 1`] = `
   text-decoration: none;
 }
 
-.c1 div {
-  margin-bottom: 0px;
-  font-size: 22px;
-  font-weight: 600;
-}
-
-.c1 div:hover {
+.c1:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   cursor: pointer;
 }
 
-.c1 div:active {
+.c1:active {
   color: rgb(33,43,50);
+  background-color: rgb(255,235,59);
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: rgb(255,235,59);
+}
+
+.c1 div {
+  margin-bottom: 0px;
+  font-size: 22px;
+  font-weight: 600;
 }
 
 <div


### PR DESCRIPTION
[2253 [Workspace Directory] Directory item link hover/active states clash](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2253)

## Acceptance Criteria
-[x] When the Workspace Directory Item is in an active/focused state, the text shouldn't be underlined.

## Pre-review checklist:

- [x] Tests

- [ ] Documentation

- [ ] Analytics (user analytics, e.g. Google Analytics)

- [ ] Observability (metrics/tracing)

- [ ] Feature flag

- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?

- Test plan?

## Test:

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)

  - [ ] Internet Explorer 11

  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader

  - [ ] Keyboard Navigation

  - [ ] Magnification

  - [ ] Contrast

  - [ ] Text size 200%

  - [ ] Touch target areas (Mobile)

  - [ ] Landscape (Mobile)
