### PR TITLE
Make Cypress workspace directory test reliable

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -5,7 +5,7 @@
   "supportFile": "./cypress/support",
   "fixturesFolder": "./cypress/fixtures/",
   "env": {
-    "TEST_WORKSPACE_ID": "750a5fb7-47da-4a8c-8d2e-399ae8d24cde",
+    "TEST_WORKSPACE_ID": "01bb9a4d-2977-4c43-b28c-2a72b4eda453",
     "TEST_WORKSPACE_NAME": "Selenium Testing"
   }
 }

--- a/frontend/cypress/integration/frontend/admin/create-workspace.js
+++ b/frontend/cypress/integration/frontend/admin/create-workspace.js
@@ -1,4 +1,4 @@
-describe("Workspace Directory", () => {
+describe("Create Workspace", () => {
   it("Shows title, renders form and submits", () => {
     cy.visit(`/admin/create-workspace`);
     cy.contains("h1", "Create a workspace");

--- a/frontend/cypress/integration/frontend/workspaces/directory.js
+++ b/frontend/cypress/integration/frontend/workspaces/directory.js
@@ -9,13 +9,11 @@ describe("Workspace Directory", () => {
   it("Navigates to workspace page", () => {
     cy.visit(`/workspaces/directory`);
 
-    cy.get("div")
-      .contains(Cypress.env("TEST_WORKSPACE_NAME"))
-      .click()
-      .then(($h3) => {
-        const text = $h3.text();
-        cy.contains("h1", text);
-        cy.contains("h2", "Most recent items");
-      });
+    cy.get("div").contains(Cypress.env("TEST_WORKSPACE_NAME")).click();
+    cy.location("pathname", {
+      timeout: Cypress.config("pageLoadTimeout"),
+    }).should("eq", `/workspaces/${Cypress.env("TEST_WORKSPACE_ID")}`);
+    cy.contains("h1", Cypress.env("TEST_WORKSPACE_NAME"));
+    cy.contains("h2", "Most recent items");
   });
 });


### PR DESCRIPTION
This build failed because the Cypress test for the workspace directory page runs into a timeout: https://github.com/FutureNHS/futurenhs-platform/runs/1363111715

It waits for a page to load after click, which takes too long because it's compiling. Locally it generally works because our laptops are fast enough.