### PR TITLE
Correlate GraphQL traces with request

### DIFF
--- a/workspace-service/Cargo.lock
+++ b/workspace-service/Cargo.lock
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.0.7"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb9b5066b57219090f1b1530aec42e962b8a18615ee337603b1f6bb525688a5"
+checksum = "6aacd1f33609c3f37792005ddfd9dd40891c6c4553a1d22cc290b3dc664c3ade"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.0.6"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b94698f5716b071b21b09f8b7145942560f2891627d86d451979bc9472ad344"
+checksum = "4865ce6f7993b9e06f8cab15ee16e083b7802fb681771510b6d18cc9eb70412c"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.0.5"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1e799ffbde17d9bc87e7969d609d45a4b1d4c15ba92183b9e0d3f1973abc8"
+checksum = "ca660e5dea2757fefec931f34c7babb01ff7eb01756494f66929cbb8411cf98a"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-tide"
-version = "2.0.7"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5d7e3ffc6d1e26436a822392541bb3cf91ecca37175f329c6906dc20d8b276"
+checksum = "13977274cfd6d6ca4a88fbfa3cbb1596f222a1960c56111c0d70bfbdb79d91ae"
 dependencies = [
  "async-graphql",
  "tide",
@@ -3846,6 +3846,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-tide",
  "async-std",
+ "async-trait",
  "azure_sdk_core",
  "azure_sdk_storage_blob",
  "azure_sdk_storage_core",

--- a/workspace-service/Cargo.toml
+++ b/workspace-service/Cargo.toml
@@ -6,12 +6,13 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.33"
 async-compat = "0.1.5"
-async-graphql = { version = "2.0.7", features = ["tracing"] }
-async-graphql-tide = "2.0.7"
+async-graphql = "=2.0.8"
+async-graphql-tide = "=2.0.8"
 async-std = {version = "1.6.5", features = ["attributes", "unstable"]}
 azure_sdk_core = "0.43.7"
 azure_sdk_storage_blob = "0.45.3"
 azure_sdk_storage_core = "0.44.4"
+async-trait = "0.1.41"
 chrono = "0.4.19"
 fnhs-event-models = {path = "../event-models/rust"}
 http-types = "2.7.0"

--- a/workspace-service/src/graphql/mod.rs
+++ b/workspace-service/src/graphql/mod.rs
@@ -5,6 +5,7 @@ mod folders;
 mod schema;
 #[cfg(test)]
 mod test_mocks;
+mod tracing_ext;
 mod users;
 mod validation;
 mod workspaces;
@@ -30,7 +31,7 @@ impl State {
     pub fn new(pool: PgPool, event_client: EventClient, azure_config: azure::Config) -> State {
         State {
             schema: Schema::build(Query::default(), Mutation::default(), EmptySubscription)
-                .extension(async_graphql::extensions::Tracing)
+                .extension(tracing_ext::Tracing)
                 .data(pool)
                 .data(event_client.clone())
                 .data(azure_config)

--- a/workspace-service/src/graphql/tracing_ext.rs
+++ b/workspace-service/src/graphql/tracing_ext.rs
@@ -1,0 +1,160 @@
+use std::collections::BTreeMap;
+
+use tracing::{span, Level, Span};
+
+use async_graphql::extensions::{Extension, ExtensionContext, ExtensionFactory, ResolveInfo};
+use async_graphql::parser::types::ExecutableDocument;
+use async_graphql::{ServerError, Variables};
+
+#[derive(Default)]
+pub struct Tracing;
+
+impl ExtensionFactory for Tracing {
+    fn create(&self) -> Box<dyn Extension> {
+        Box::new(TracingExtension::default())
+    }
+}
+
+#[derive(Default)]
+struct TracingExtension {
+    root: Option<Span>,
+    parse: Option<Span>,
+    validation: Option<Span>,
+    execute: Option<Span>,
+    fields: BTreeMap<usize, Span>,
+}
+
+impl Extension for TracingExtension {
+    fn parse_start(
+        &mut self,
+        _ctx: &ExtensionContext<'_>,
+        query_source: &str,
+        _variables: &Variables,
+    ) {
+        let root_span = span!(
+            target: "async_graphql::graphql",
+            Level::INFO,
+            "query",
+            source = %query_source
+        );
+
+        let parse_span = span!(
+            target: "async_graphql::graphql",
+            parent: &root_span,
+            Level::INFO,
+            "parse"
+        );
+
+        root_span.with_subscriber(|(id, d)| d.enter(id));
+        self.root.replace(root_span);
+
+        parse_span.with_subscriber(|(id, d)| d.enter(id));
+        self.parse.replace(parse_span);
+    }
+
+    fn parse_end(&mut self, _ctx: &ExtensionContext<'_>, _document: &ExecutableDocument) {
+        self.parse
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+    }
+
+    fn validation_start(&mut self, _ctx: &ExtensionContext<'_>) {
+        if let Some(parent) = &self.root {
+            let validation_span = span!(
+                target: "async_graphql::graphql",
+                parent: parent,
+                Level::INFO,
+                "validation"
+            );
+            validation_span.with_subscriber(|(id, d)| d.enter(id));
+            self.validation.replace(validation_span);
+        }
+    }
+
+    fn validation_end(&mut self, _ctx: &ExtensionContext<'_>) {
+        self.validation
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+    }
+
+    fn execution_start(&mut self, _ctx: &ExtensionContext<'_>) {
+        let execute_span = if let Some(parent) = &self.root {
+            span!(
+                target: "async_graphql::graphql",
+                parent: parent,
+                Level::INFO,
+                "execute"
+            )
+        } else {
+            // For every step of the subscription stream.
+            span!(
+                target: "async_graphql::graphql",
+                Level::INFO,
+                "execute"
+            )
+        };
+
+        execute_span.with_subscriber(|(id, d)| d.enter(id));
+        self.execute.replace(execute_span);
+    }
+
+    fn execution_end(&mut self, _ctx: &ExtensionContext<'_>) {
+        self.execute
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+
+        self.root
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+    }
+
+    fn resolve_start(&mut self, _ctx: &ExtensionContext<'_>, info: &ResolveInfo<'_>) {
+        let parent_span = match info.resolve_id.parent {
+            Some(parent_id) if parent_id > 0 => self.fields.get(&parent_id),
+            _ => self.execute.as_ref(),
+        };
+
+        if let Some(parent_span) = parent_span {
+            let span = span!(
+                target: "async_graphql::graphql",
+                parent: parent_span,
+                Level::INFO,
+                "field",
+                id = %info.resolve_id.current,
+                path = %info.path_node,
+                parent_type = %info.parent_type,
+                return_type = %info.return_type,
+            );
+            span.with_subscriber(|(id, d)| d.enter(id));
+            self.fields.insert(info.resolve_id.current, span);
+        }
+    }
+
+    fn resolve_end(&mut self, _ctx: &ExtensionContext<'_>, info: &ResolveInfo<'_>) {
+        if let Some(span) = self.fields.remove(&info.resolve_id.current) {
+            span.with_subscriber(|(id, d)| d.exit(id));
+        }
+    }
+
+    fn error(&mut self, _ctx: &ExtensionContext<'_>, err: &ServerError) {
+        tracing::error!(target: "async_graphql::graphql", error = %err.message);
+
+        for span in self.fields.values() {
+            span.with_subscriber(|(id, d)| d.exit(id));
+        }
+        self.fields.clear();
+
+        self.execute
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+        self.validation
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+        self.parse
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+        self.root
+            .take()
+            .and_then(|span| span.with_subscriber(|(id, d)| d.exit(id)));
+    }
+}

--- a/workspace-service/src/lib.rs
+++ b/workspace-service/src/lib.rs
@@ -5,32 +5,30 @@ mod graphql;
 
 use fnhs_event_models::EventClient;
 pub use graphql::generate_graphql_schema;
-use opentelemetry::api::Extractor;
+use opentelemetry::api::{Extractor, TraceContextExt};
 use sqlx::PgPool;
-use std::future::Future;
-use std::pin::Pin;
-use tide::{Next, Redirect, Request, Server};
+use tide::{Middleware, Next, Redirect, Request, Server};
 use tracing::info_span;
 use tracing_futures::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-struct RequestExtractor<'a> {
-    req: &'a Request<graphql::State>,
+struct RequestExtractor<'a, State> {
+    req: &'a Request<State>,
 }
 
-impl<'a> Extractor for RequestExtractor<'a> {
+impl<'a, State> Extractor for RequestExtractor<'a, State> {
     /// Get a value for a key from the HeaderMap.  If the value is not valid ASCII, returns None.
     fn get(&self, key: &str) -> Option<&str> {
         self.req.header(key).map(|value| value.as_str())
     }
 }
 
-pub fn log<'a>(
-    req: Request<graphql::State>,
-    next: Next<'a, graphql::State>,
-) -> Pin<Box<dyn Future<Output = Result<tide::Response, http_types::Error>> + Send + 'a>> {
-    Box::pin(async {
-        let remote_context = opentelemetry::global::get_http_text_propagator(|propagator| {
+struct TracingMiddleware;
+
+#[async_trait::async_trait]
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for TracingMiddleware {
+    async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> tide::Result {
+        let parent_context = opentelemetry::global::get_http_text_propagator(|propagator| {
             propagator.extract(&RequestExtractor { req: &req })
         });
 
@@ -41,13 +39,24 @@ pub fn log<'a>(
             http.method = req.method().as_ref(),
             http.target = req.url().as_ref()
         );
-        span.set_parent(&remote_context);
+
+        // B3Propagator has a bug in version, which should be fixed in opentelemetry >0.9.1. When
+        // no headers are present it returns an invalid span context, which causes propagation to
+        // fail. This check if a workaround. After the version upgrade we can unconditionally call
+        // set_parent.
+        if (parent_context
+            .remote_span_context()
+            .map(|span_context| span_context.is_valid())
+            .unwrap_or(false))
+        {
+            span.set_parent(&parent_context);
+        }
 
         let res = next.run(req).instrument(span.clone()).await;
         span.record("http.status_code", &u16::from(res.status()));
 
         Ok(res)
-    })
+    }
 }
 
 pub async fn create_app(
@@ -61,7 +70,7 @@ pub async fn create_app(
         azure_config,
     ));
 
-    app.with(log);
+    app.with(TracingMiddleware);
 
     app.at("/").get(Redirect::permanent("/graphiql"));
     app.at("/healthz").get(graphql::handle_healthz);


### PR DESCRIPTION
- Ticket: [AB#2351](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/2351)

## Acceptance criteria

The tracing extension, that comes with async-graphql currently forces
every GraphQL query to be in a new trace. We want it to be part of the
request trace, though. This vendors the extension. I will suggest a
change the async-graphql later and see if we can get this upstreamed.

I also noticed async-graphql doesn't call the error handler of the
extension anymore since version 2.0.9. This is why I fixed the version
to 2.0.8 for now. Similarly I will open an issue for this.

This commit also fixes an issue with the B3Propagator, which is
explained in a code comment.

## Testing information

Deploy to production and look at App Insights.

I already tested this extensively locally using Jaeger.

## Test checklist

- [x] Tested locally