### PR TITLE
[Bug 2255] Add focus/active state to folder nav chevron

### DIFF
--- a/frontend/components/Icon/ChevronBottomIcon.tsx
+++ b/frontend/components/Icon/ChevronBottomIcon.tsx
@@ -2,9 +2,11 @@ import React from "react";
 
 interface Props {
   className?: string;
+  title?: string;
+  description?: string;
 }
 
-const ChevronBottomIcon = ({ className }: Props) => (
+const ChevronBottomIcon = ({ className, title, description }: Props) => (
   <div className={`icon-wrapper ${className || ""}`}>
     <svg
       width="24"
@@ -12,7 +14,10 @@ const ChevronBottomIcon = ({ className }: Props) => (
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby="chevronBottomIconId chevronBottomIconDesc"
     >
+      {title ? <title id="chevronBottomIconId">{title}</title> : ""}
+      {description ? <desc id="chevronBottomIconDesc">{description}</desc> : ""}
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/frontend/components/Icon/ChevronTopIcon.tsx
+++ b/frontend/components/Icon/ChevronTopIcon.tsx
@@ -2,9 +2,11 @@ import React from "react";
 
 interface Props {
   className?: string;
+  title?: string;
+  description?: string;
 }
 
-const ChevronTopIcon = ({ className }: Props) => (
+const ChevronTopIcon = ({ className, title, description }: Props) => (
   <div className={`icon-wrapper ${className || ""}`}>
     <svg
       width="24"
@@ -12,7 +14,10 @@ const ChevronTopIcon = ({ className }: Props) => (
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby="chevronTopIconId chevronTopIconDesc"
     >
+      {title ? <title id="chevronTopIconId">{title}</title> : ""}
+      {description ? <desc id="chevronTopIconDesc">{description}</desc> : ""}
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/frontend/components/NavSection/NavSection.tsx
+++ b/frontend/components/NavSection/NavSection.tsx
@@ -15,6 +15,8 @@ const Section = styled.section`
   button {
     border: none;
     background: inherit;
+  }
+  .chevron {
     outline: inherit;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;
@@ -41,7 +43,7 @@ const NavSection = ({
     <Section>
       <div>
         <h4>{title}</h4>
-        <button onClick={() => setOpen(!open)}>
+        <button className="chevron" onClick={() => setOpen(!open)}>
           {open ? (
             <ChevronTopIcon title={`Hide ${title}`} />
           ) : (

--- a/frontend/components/NavSection/NavSection.tsx
+++ b/frontend/components/NavSection/NavSection.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 
 import styled from "styled-components";
 
+import { ChevronBottomIcon, ChevronTopIcon } from "../Icon";
+
 const Section = styled.section`
   padding-top: 20px;
   div {
@@ -13,6 +15,14 @@ const Section = styled.section`
   button {
     border: none;
     background: inherit;
+    outline: inherit;
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    cursor: pointer;
+    :focus {
+      background-color: ${({ theme }) => theme.colorNhsukYellow};
+      border-bottom: 4px solid ${({ theme }) => theme.colorNhsukBlack};
+    }
   }
 `;
 
@@ -27,17 +37,15 @@ const NavSection = ({
 }) => {
   const [open, setOpen] = useState(initiallyOpen);
 
-  const openChevron = require("../../public/chevronOpen.svg");
-  const closedChevron = require("../../public/chevronClosed.svg");
   return (
     <Section>
       <div>
         <h4>{title}</h4>
         <button onClick={() => setOpen(!open)}>
           {open ? (
-            <img src={openChevron} alt={`Hide ${title}`} />
+            <ChevronTopIcon title={`Hide ${title}`} />
           ) : (
-            <img src={closedChevron} alt={`Show ${title}`} />
+            <ChevronBottomIcon title={`Show ${title}`} />
           )}
         </button>
       </div>

--- a/frontend/components/NavSection/NavSection.tsx
+++ b/frontend/components/NavSection/NavSection.tsx
@@ -17,6 +17,7 @@ const Section = styled.section`
     background: inherit;
   }
   .chevron {
+    color: ${({ theme }) => theme.colorNhsukBlack};
     outline: inherit;
     border-top: 4px solid transparent;
     border-bottom: 4px solid transparent;

--- a/frontend/components/NavSection/__snapshots__/NavSection.test.tsx.snap
+++ b/frontend/components/NavSection/__snapshots__/NavSection.test.tsx.snap
@@ -27,13 +27,16 @@ exports[`<NavSection/> does not render children when closed 1`] = `
 .c0 button {
   border: none;
   background: inherit;
+}
+
+.c0 .chevron {
   outline: inherit;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
   cursor: pointer;
 }
 
-.c0 button:focus {
+.c0 .chevron:focus {
   background-color: rgb(255,235,59);
   border-bottom: 4px solid rgb(33,43,50);
 }
@@ -45,7 +48,9 @@ exports[`<NavSection/> does not render children when closed 1`] = `
       <h4>
         Folders
       </h4>
-      <button>
+      <button
+        class="chevron"
+      >
         <div
           class="icon-wrapper "
         >
@@ -103,13 +108,16 @@ exports[`<NavSection/> shows children when open (default) 1`] = `
 .c0 button {
   border: none;
   background: inherit;
+}
+
+.c0 .chevron {
   outline: inherit;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
   cursor: pointer;
 }
 
-.c0 button:focus {
+.c0 .chevron:focus {
   background-color: rgb(255,235,59);
   border-bottom: 4px solid rgb(33,43,50);
 }
@@ -121,7 +129,9 @@ exports[`<NavSection/> shows children when open (default) 1`] = `
       <h4>
         Folders
       </h4>
-      <button>
+      <button
+        class="chevron"
+      >
         <div
           class="icon-wrapper "
         >

--- a/frontend/components/NavSection/__snapshots__/NavSection.test.tsx.snap
+++ b/frontend/components/NavSection/__snapshots__/NavSection.test.tsx.snap
@@ -27,6 +27,15 @@ exports[`<NavSection/> does not render children when closed 1`] = `
 .c0 button {
   border: none;
   background: inherit;
+  outline: inherit;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  cursor: pointer;
+}
+
+.c0 button:focus {
+  background-color: rgb(255,235,59);
+  border-bottom: 4px solid rgb(33,43,50);
 }
 
 <section
@@ -37,10 +46,30 @@ exports[`<NavSection/> does not render children when closed 1`] = `
         Folders
       </h4>
       <button>
-        <img
-          alt="Show Folders"
-          src="/public/chevronClosed.svg"
-        />
+        <div
+          class="icon-wrapper "
+        >
+          <svg
+            aria-labelledby="chevronBottomIconId chevronBottomIconDesc"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title
+              id="chevronBottomIconId"
+            >
+              Show Folders
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M11.5 16.5C11.1 16.5 10.8333 16.3714 10.5667 16.1143L3.9 9.68571C3.36667 9.17143 3.36667 8.4 3.9 7.88571C4.43333 7.37143 5.23333 7.37143 5.76667 7.88571L11.5 13.4143L17.2333 7.88571C17.7667 7.37143 18.5667 7.37143 19.1 7.88571C19.6333 8.4 19.6333 9.17143 19.1 9.68571L12.4333 16.1143C12.1667 16.3714 11.9 16.5 11.5 16.5V16.5Z"
+              fill="#425462"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
       </button>
     </div>
   </section>
@@ -74,6 +103,15 @@ exports[`<NavSection/> shows children when open (default) 1`] = `
 .c0 button {
   border: none;
   background: inherit;
+  outline: inherit;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  cursor: pointer;
+}
+
+.c0 button:focus {
+  background-color: rgb(255,235,59);
+  border-bottom: 4px solid rgb(33,43,50);
 }
 
 <section
@@ -84,10 +122,30 @@ exports[`<NavSection/> shows children when open (default) 1`] = `
         Folders
       </h4>
       <button>
-        <img
-          alt="Hide Folders"
-          src="/public/chevronOpen.svg"
-        />
+        <div
+          class="icon-wrapper "
+        >
+          <svg
+            aria-labelledby="chevronTopIconId chevronTopIconDesc"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title
+              id="chevronTopIconId"
+            >
+              Hide Folders
+            </title>
+            <path
+              clip-rule="evenodd"
+              d="M12.5 7.5C12.9 7.5 13.1667 7.62857 13.4333 7.88571L20.1 14.3143C20.6333 14.8286 20.6333 15.6 20.1 16.1143C19.5667 16.6286 18.7667 16.6286 18.2333 16.1143L12.5 10.5857L6.76667 16.1143C6.23333 16.6286 5.43333 16.6286 4.9 16.1143C4.36667 15.6 4.36667 14.8286 4.9 14.3143L11.5667 7.88571C11.8333 7.62857 12.1 7.5 12.5 7.5V7.5Z"
+              fill="#425462"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
       </button>
     </div>
     Look at me! I am children!

--- a/frontend/components/NavSection/__snapshots__/NavSection.test.tsx.snap
+++ b/frontend/components/NavSection/__snapshots__/NavSection.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`<NavSection/> does not render children when closed 1`] = `
 }
 
 .c0 .chevron {
+  color: rgb(33,43,50);
   outline: inherit;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
@@ -111,6 +112,7 @@ exports[`<NavSection/> shows children when open (default) 1`] = `
 }
 
 .c0 .chevron {
+  color: rgb(33,43,50);
   outline: inherit;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -214,6 +214,15 @@ exports[`<Navigation/> renders correctly 1`] = `
 .c5 button {
   border: none;
   background: inherit;
+  outline: inherit;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  cursor: pointer;
+}
+
+.c5 button:focus {
+  background-color: rgb(255,235,59);
+  border-bottom: 4px solid rgb(33,43,50);
 }
 
 .c0 {
@@ -363,10 +372,30 @@ exports[`<Navigation/> renders correctly 1`] = `
           Folders
         </h4>
         <button>
-          <img
-            alt="Hide Folders"
-            src="/public/chevronOpen.svg"
-          />
+          <div
+            class="icon-wrapper "
+          >
+            <svg
+              aria-labelledby="chevronTopIconId chevronTopIconDesc"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="chevronTopIconId"
+              >
+                Hide Folders
+              </title>
+              <path
+                clip-rule="evenodd"
+                d="M12.5 7.5C12.9 7.5 13.1667 7.62857 13.4333 7.88571L20.1 14.3143C20.6333 14.8286 20.6333 15.6 20.1 16.1143C19.5667 16.6286 18.7667 16.6286 18.2333 16.1143L12.5 10.5857L6.76667 16.1143C6.23333 16.6286 5.43333 16.6286 4.9 16.1143C4.36667 15.6 4.36667 14.8286 4.9 14.3143L11.5667 7.88571C11.8333 7.62857 12.1 7.5 12.5 7.5V7.5Z"
+                fill="#425462"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
         </button>
       </div>
       <ul

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -217,6 +217,7 @@ exports[`<Navigation/> renders correctly 1`] = `
 }
 
 .c5 .chevron {
+  color: rgb(33,43,50);
   outline: inherit;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;

--- a/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
+++ b/frontend/components/Navigation/__snapshots__/Navigation.test.tsx.snap
@@ -214,13 +214,16 @@ exports[`<Navigation/> renders correctly 1`] = `
 .c5 button {
   border: none;
   background: inherit;
+}
+
+.c5 .chevron {
   outline: inherit;
   border-top: 4px solid transparent;
   border-bottom: 4px solid transparent;
   cursor: pointer;
 }
 
-.c5 button:focus {
+.c5 .chevron:focus {
   background-color: rgb(255,235,59);
   border-bottom: 4px solid rgb(33,43,50);
 }
@@ -371,7 +374,9 @@ exports[`<Navigation/> renders correctly 1`] = `
         <h4>
           Folders
         </h4>
-        <button>
+        <button
+          class="chevron"
+        >
           <div
             class="icon-wrapper "
           >

--- a/frontend/components/Permissions/Permissions.tsx
+++ b/frontend/components/Permissions/Permissions.tsx
@@ -48,11 +48,7 @@ const Permissions: React.FC<PermissionsProps> = ({ inputRef }) => {
     <>
       <TitleContainer>
         <h3>Permissions</h3>
-        <button
-          type="button"
-          aria-label="permissions"
-          onClick={() => setExpandedState(!expanded)}
-        >
+        <button type="button" onClick={() => setExpandedState(!expanded)}>
           {expanded ? (
             <ChevronTopIcon title={`Hide permissions`} />
           ) : (

--- a/frontend/components/Permissions/Permissions.tsx
+++ b/frontend/components/Permissions/Permissions.tsx
@@ -53,7 +53,11 @@ const Permissions: React.FC<PermissionsProps> = ({ inputRef }) => {
           aria-label="permissions"
           onClick={() => setExpandedState(!expanded)}
         >
-          {expanded ? <ChevronTopIcon /> : <ChevronBottomIcon />}
+          {expanded ? (
+            <ChevronTopIcon title={`Hide permissions`} />
+          ) : (
+            <ChevronBottomIcon title={`Show permissions`} />
+          )}
         </button>
       </TitleContainer>
       <Description>

--- a/frontend/components/Permissions/__snapshots__/Permissions.test.tsx.snap
+++ b/frontend/components/Permissions/__snapshots__/Permissions.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`Permissions renders matching snapshot 1`] = `
       Permissions
     </h3>
     <button
-      aria-label="permissions"
       type="button"
     >
       <div

--- a/frontend/components/Permissions/__snapshots__/Permissions.test.tsx.snap
+++ b/frontend/components/Permissions/__snapshots__/Permissions.test.tsx.snap
@@ -46,12 +46,18 @@ exports[`Permissions renders matching snapshot 1`] = `
         class="icon-wrapper "
       >
         <svg
+          aria-labelledby="chevronBottomIconId chevronBottomIconDesc"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <title
+            id="chevronBottomIconId"
+          >
+            Show permissions
+          </title>
           <path
             clip-rule="evenodd"
             d="M11.5 16.5C11.1 16.5 10.8333 16.3714 10.5667 16.1143L3.9 9.68571C3.36667 9.17143 3.36667 8.4 3.9 7.88571C4.43333 7.37143 5.23333 7.37143 5.76667 7.88571L11.5 13.4143L17.2333 7.88571C17.7667 7.37143 18.5667 7.37143 19.1 7.88571C19.6333 8.4 19.6333 9.17143 19.1 9.68571L12.4333 16.1143C12.1667 16.3714 11.9 16.5 11.5 16.5V16.5Z"


### PR DESCRIPTION
<img src="https://media.giphy.com/media/fBPImTicFX4215X1PA/giphy.gif" />

- Ticket: [[AB#2255](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/2255) - [Folder Navigation] Dropdown chevron :focus/:hover/:active states are missing](https://dev.azure.com/futurenhs/FutureNHS/_workitems/edit/2255)

## Acceptance criteria
- [x] :focus/:active - There shouldn't be an outline and the background colour should be yellow with black border-bottom.

## Pre-review checklist

- [ ] Tests
- [ ] Documentation
- [ ] Analytics (user analytics, e.g. Google Analytics)
- [ ] Observability (metrics/tracing)
- [ ] Feature flag
- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?
- Test plan?

## Test checklist

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)
  - [ ] Internet Explorer 11
  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader
  - [ ] Keyboard Navigation
  - [ ] Magnification
  - [ ] Contrast
  - [ ] Text size 200%
  - [ ] Touch target areas (Mobile)
  - [ ] Landscape (Mobile)
