### PR TITLE
Support both single and multi header B3 encoding

### DIFF
--- a/workspace-service/src/main.rs
+++ b/workspace-service/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use fnhs_event_models::EventClient;
 use opentelemetry::{
-    api::{self, Provider},
+    api::{trace::b3_propagator::B3Encoding, B3Propagator, Provider},
     global, sdk,
     sdk::BatchSpanProcessor,
 };
@@ -47,7 +47,8 @@ async fn main() -> Result<()> {
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
     let subscriber = Registry::default().with(telemetry);
     tracing::subscriber::set_global_default(subscriber)?;
-    let propagator = api::B3Propagator::new();
+
+    let propagator = B3Propagator::with_encoding(B3Encoding::SingleAndMultiHeader);
     global::set_http_text_propagator(propagator);
 
     let connection_pool = PgPool::connect(config.database_url.expect("required").as_str()).await?;


### PR DESCRIPTION
- Ticket: [AB#2351](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/2351)

## Acceptance criteria

The default encoding in OpenTelemetry seems to have changed over one of the last versions. It's probably easier if we accept both.

## Testing information

Again the final test has to happen in production to make sure App Insights can correlate the traces correctly.

## Test checklist

- [x] Tested locally