### PR TITLE
Fix yarn: Extracting tar content of undefined failed

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+@futurenhs:registry=https://npm.pkg.github.com

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,0 @@
-@futurenhs:registry=https://npm.pkg.github.com

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "next-images": "^1.4.1",
     "next-urql": "^1.1.0",
     "nhsuk-frontend": "^3.1.0",
-    "@futurenhs/nhsuk-react-components": "^1.2.6",
+    "nhsuk-react-components": "https://raw.githubusercontent.com/FutureNHS/nhsuk-react-components/packages/futurenhs-nhsuk-react-components-1.2.6.tgz",
     "node-sass": "^4.14.1",
     "passport": "^0.4.1",
     "passport-azure-ad": "^4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "next-images": "^1.4.1",
     "next-urql": "^1.1.0",
     "nhsuk-frontend": "^3.1.0",
-    "nhsuk-react-components": "git://github.com/FutureNHS/nhsuk-react-components#fix-input-ref-type",
+    "@futurenhs/nhsuk-react-components": "^1.2.6",
     "node-sass": "^4.14.1",
     "passport": "^0.4.1",
     "passport-azure-ad": "^4.3.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1462,6 +1462,13 @@
     ajv "^6.12.6"
     typescript "^4.0.5"
 
+"@futurenhs/nhsuk-react-components@^1.2.6":
+  version "1.2.6"
+  resolved "https://npm.pkg.github.com/download/@futurenhs/nhsuk-react-components/1.2.6/fac4896c8c837d46158f23ea44c8e5d83177fac8f96bcabf47ce3b6dd21a2f86#3f43df8aa513a21e7b61e806b4c115528ae5ea31"
+  integrity sha512-XNDbbkvLC62lxUQiB+C14HVRcbb77dybauW36rzKymTphuuy2/0oBoXXScUDHF9J+sinrdC9tht+P8igKppUmg==
+  dependencies:
+    classnames "^2.2.6"
+
 "@graphql-codegen/cli@1.19.1":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.19.1.tgz#2f4ad535f3106af1f3b2422878d78405c556c1c1"
@@ -9491,12 +9498,6 @@ nhsuk-frontend@^3.1.0:
   dependencies:
     accessible-autocomplete "^2.0.2"
     sass-mq "^5.0.1"
-
-"nhsuk-react-components@git://github.com/FutureNHS/nhsuk-react-components#fix-input-ref-type":
-  version "1.2.6"
-  resolved "git://github.com/FutureNHS/nhsuk-react-components#e455c0a4cb58810656a2b0d361c583fcb2df2595"
-  dependencies:
-    classnames "^2.2.6"
 
 nice-try@^1.0.4:
   version "1.0.5"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1462,13 +1462,6 @@
     ajv "^6.12.6"
     typescript "^4.0.5"
 
-"@futurenhs/nhsuk-react-components@^1.2.6":
-  version "1.2.6"
-  resolved "https://npm.pkg.github.com/download/@futurenhs/nhsuk-react-components/1.2.6/fac4896c8c837d46158f23ea44c8e5d83177fac8f96bcabf47ce3b6dd21a2f86#3f43df8aa513a21e7b61e806b4c115528ae5ea31"
-  integrity sha512-XNDbbkvLC62lxUQiB+C14HVRcbb77dybauW36rzKymTphuuy2/0oBoXXScUDHF9J+sinrdC9tht+P8igKppUmg==
-  dependencies:
-    classnames "^2.2.6"
-
 "@graphql-codegen/cli@1.19.1":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.19.1.tgz#2f4ad535f3106af1f3b2422878d78405c556c1c1"
@@ -9498,6 +9491,12 @@ nhsuk-frontend@^3.1.0:
   dependencies:
     accessible-autocomplete "^2.0.2"
     sass-mq "^5.0.1"
+
+"nhsuk-react-components@https://raw.githubusercontent.com/FutureNHS/nhsuk-react-components/packages/futurenhs-nhsuk-react-components-1.2.6.tgz":
+  version "1.2.6"
+  resolved "https://raw.githubusercontent.com/FutureNHS/nhsuk-react-components/packages/futurenhs-nhsuk-react-components-1.2.6.tgz#3f43df8aa513a21e7b61e806b4c115528ae5ea31"
+  dependencies:
+    classnames "^2.2.6"
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
We recently added nhsuk-react-components as a git dependency, because we
want to use features from the latest master branch, which have not been
released, yet.

This has caused a bug, where builds were randomly failing with the
error:

    yarn install v1.22.5
    [1/4] Resolving packages...
    [2/4] Fetching packages...
    [1/4] Resolving packages...
    [2/4] Fetching packages...
    error https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, chmod '/home/runner/.cache/yarn/v6/npm-yaml-1.10.0-3b593add944876077d4d683fee01081bd9fff31e-integrity/node_modules/yaml/util.mjs'"

It looks like this issue: https://github.com/yarnpkg/yarn/issues/7212

This fixes it by installing a version of the nhsuk-react-components
through a tarball, which we added to the forked to a GitHub repo.

To create a tarball: https://docs.npmjs.com/cli/v6/commands/npm-pack