### PR TITLE
Create 'get workspace permissions' query and frontend Error component. 

### DIFF
--- a/frontend/components/Error/Error.test.tsx
+++ b/frontend/components/Error/Error.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { render } from "@testing-library/react";
+
+import Error from "./Error";
+
+describe(Error, () => {
+  it("renders matching snapshot", () => {
+    const props = {
+      title: "Insufficient Permissions",
+      description: "Please contact your administrator",
+    };
+    const container = render(<Error {...props} />);
+
+    expect(container.asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/components/Error/Error.tsx
+++ b/frontend/components/Error/Error.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { H2 } from "../H2";
+import { MainHeading } from "../MainHeading";
+
+interface ErrorProps {
+  title: string;
+  description: string;
+}
+
+const Error: React.FC<ErrorProps> = ({ title, description }) => {
+  return (
+    <>
+      <MainHeading>Error</MainHeading>
+      <H2 title={title} />
+      <br />
+      <p>{description}</p>
+    </>
+  );
+};
+
+export default Error;

--- a/frontend/components/Error/__snapshots__/Error.test.tsx.snap
+++ b/frontend/components/Error/__snapshots__/Error.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Error renders matching snapshot 1`] = `
+<DocumentFragment>
+  .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c1 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  font-size: 40px;
+  line-height: 1.25;
+  overflow-wrap: break-word;
+  padding-top: 24px;
+  width: 0px;
+}
+
+<div
+    class="c0"
+  >
+    <h1
+      aria-live="polite"
+      class="c1"
+    >
+      Error
+    </h1>
+  </div>
+  <h2>
+    Insufficient Permissions
+  </h2>
+  <br />
+  <p>
+    Please contact your administrator
+  </p>
+</DocumentFragment>
+`;

--- a/frontend/components/Error/index.tsx
+++ b/frontend/components/Error/index.tsx
@@ -1,0 +1,3 @@
+import Error from "./Error";
+
+export { Error };

--- a/frontend/lib/withUrqlClient.ts
+++ b/frontend/lib/withUrqlClient.ts
@@ -171,8 +171,16 @@ export default function withUrqlClient(
       if (process.env.NODE_ENV !== "production") {
         exchanges.unshift(devtoolsExchange);
       }
-
+      const fetchOptions = isServerSide
+        ? {
+            headers: {
+              // @ts-ignore
+              "x-user-auth-id": ctx?.req?.user.authId,
+            },
+          }
+        : undefined;
       return {
+        fetchOptions,
         exchanges,
         url: workspaceAPIServerUrl,
       };

--- a/frontend/pages/admin/create-workspace.tsx
+++ b/frontend/pages/admin/create-workspace.tsx
@@ -5,6 +5,7 @@ import { Input, Form, Button } from "nhsuk-react-components";
 import { useForm } from "react-hook-form/dist/index.ie11";
 import styled from "styled-components";
 
+import { Error } from "../../components/Error";
 import { Footer } from "../../components/Footer";
 import { H2 } from "../../components/H2";
 import { Head } from "../../components/Head";
@@ -111,13 +112,11 @@ export const CreateWorkspace: NextPage<InitialProps> = ({
             </>
           ) : (
             <>
-              <MainHeading>Error</MainHeading>
-              <H2 title="You do not have permission to do this." />
-              <br />
-              <p>
-                Please contact your Platform Administrator to request a
-                workspace.
-              </p>
+              <Error
+                title="You do not have permission to do this."
+                description="Please contact your Platform Administrator to request a
+                workspace."
+              />
             </>
           )}
         </PageContent>

--- a/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/index.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/index.tsx
@@ -27,11 +27,9 @@ import { PageLayout } from "../../../../../components/PageLayout";
 import { MobileList, Table } from "../../../../../components/Table";
 import {
   File,
-  RoleRequired,
   useFilesByFolderQuery,
   useGetFolderByIdQuery,
   useGetWorkspaceByIdQuery,
-  useGetWorkspaceMembershipQuery,
 } from "../../../../../lib/generated/graphql";
 import withUrqlClient from "../../../../../lib/withUrqlClient";
 
@@ -88,20 +86,8 @@ const FolderHomepage: NextPage = () => {
     variables: { folder: folderId },
   });
 
-  const [returnedUserPermissons] = useGetWorkspaceMembershipQuery({
-    variables: {
-      workspaceId,
-    },
-  });
-
-  const userRole = returnedUserPermissons.data?.getWorkspaceMembership;
-  const folderAccessLevel = folder.data?.folder.roleRequired;
-
-  // If the folder only permits workspace members to view, and the user is not
-  // a member of the workspace, then set accessPermitted to false.
   const accessPermitted =
-    folderAccessLevel === RoleRequired.WorkspaceMember &&
-    userRole === "NON_MEMBER"
+    folder.error?.graphQLErrors[0]?.extensions?.details === "ACCESS_DENIED"
       ? false
       : true;
 

--- a/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
@@ -20,7 +20,6 @@ import {
   useGetFolderByIdQuery,
   useGetWorkspaceByIdQuery,
   RoleRequired,
-  useGetWorkspaceMembershipQuery,
 } from "../../../../../lib/generated/graphql";
 import { useMaxLengthHelper } from "../../../../../lib/useMaxLengthHelper";
 import withUrqlClient from "../../../../../lib/withUrqlClient";
@@ -78,20 +77,8 @@ const UpdateFolder: NextPage = () => {
 
   const [, updateFolder] = useUpdateFolderMutation();
 
-  const [returnedUserPermissons] = useGetWorkspaceMembershipQuery({
-    variables: {
-      workspaceId,
-    },
-  });
-
-  const userRole = returnedUserPermissons.data?.getWorkspaceMembership;
-  const folderAccessLevel = folder.data?.folder.roleRequired;
-
-  // If the folder only permits workspace members to view, and the user is not
-  // a member of the workspace, then set accessPermitted to false.
   const accessPermitted =
-    folderAccessLevel === RoleRequired.WorkspaceMember &&
-    userRole === "NON_MEMBER"
+    folder.error?.graphQLErrors[0]?.extensions?.details === "ACCESS_DENIED"
       ? false
       : true;
 

--- a/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
@@ -14,11 +14,13 @@ import { Navigation } from "../../../../../components/Navigation";
 import { PageLayout } from "../../../../../components/PageLayout";
 import { Permissions } from "../../../../../components/Permissions";
 import { Textarea } from "../../../../../components/Textarea";
+import { User } from "../../../../../lib/auth";
 import {
   useUpdateFolderMutation,
   useGetFolderByIdQuery,
   useGetWorkspaceByIdQuery,
   RoleRequired,
+  useGetWorkspaceMembershipQuery,
 } from "../../../../../lib/generated/graphql";
 import { useMaxLengthHelper } from "../../../../../lib/useMaxLengthHelper";
 import withUrqlClient from "../../../../../lib/withUrqlClient";
@@ -58,7 +60,11 @@ interface FolderInputs {
   server?: never;
 }
 
-const UpdateFolder: NextPage = () => {
+interface InitialProps {
+  user: User | undefined;
+}
+
+const UpdateFolder: NextPage<InitialProps> = () => {
   const router = useRouter();
   const { workspaceId, folderId } = router.query;
 
@@ -75,6 +81,14 @@ const UpdateFolder: NextPage = () => {
   });
 
   const [, updateFolder] = useUpdateFolderMutation();
+
+  const [returnedUser] = useGetWorkspaceMembershipQuery({
+    variables: {
+      workspaceId,
+    },
+  });
+
+  console.log(returnedUser);
 
   const titleMaxLength = useMaxLengthHelper("Title", 100);
   const descriptionMaxLength = useMaxLengthHelper("Description", 250);

--- a/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
@@ -6,6 +6,7 @@ import { Input, Form, Button, ErrorMessage } from "nhsuk-react-components";
 import { useForm } from "react-hook-form/dist/index.ie11";
 import styled from "styled-components";
 
+import { Error as ErrorComponent } from "../../../../../components/Error";
 import { Footer } from "../../../../../components/Footer";
 import { H2 } from "../../../../../components/H2";
 import { MainHeading } from "../../../../../components/MainHeading";
@@ -88,7 +89,15 @@ const UpdateFolder: NextPage<InitialProps> = () => {
     },
   });
 
-  console.log(returnedUser);
+  const userRole = returnedUser.data?.getWorkspaceMembership;
+  const folderAccessLevel = folder.data?.folder.roleRequired;
+
+  // If the folder only permits workspace members to view, and the user is not
+  // a member of the workspace, then set accessPermitted to false.
+  const accessPermitted =
+    folderAccessLevel === "WORKSPACE_MEMBER" && userRole === "NON_MEMBER"
+      ? false
+      : true;
 
   const titleMaxLength = useMaxLengthHelper("Title", 100);
   const descriptionMaxLength = useMaxLengthHelper("Description", 250);
@@ -138,67 +147,85 @@ const UpdateFolder: NextPage<InitialProps> = () => {
   };
 
   return (
-    <PageLayout>
-      <NavHeader />
-      <ContentWrapper>
-        <Navigation
-          workspaceId={workspaceId}
-          workspaceTitle={data.workspace.title}
-          activeFolder={folderId}
-        />
-        <PageContent>
-          <MainHeading>Edit folder</MainHeading>
-          <H2 title="Folder details" />
-          <p> Fields marked with * are mandatory.</p>
-          <Form onSubmit={handleSubmit(onSubmit)}>
-            <FormField>
-              <Input
-                name="title"
-                onChange={titleMaxLength.onChange}
-                id="title"
-                label="Enter folder title*"
-                hint="The title of your folder should accurately reflect its content or audience"
-                inputRef={register({
-                  required: {
-                    value: true,
-                    message: "Title is required",
-                  },
-                  ...titleMaxLength.validation,
-                })}
-                error={errors.title?.message}
-              />
-              {titleMaxLength.remainingText("title")}
-            </FormField>
+    <>
+      <PageLayout>
+        <NavHeader />
+        <ContentWrapper>
+          <Navigation
+            workspaceId={workspaceId}
+            workspaceTitle={data.workspace.title}
+            activeFolder={folderId}
+          />
+          <PageContent>
+            {accessPermitted ? (
+              <>
+                <MainHeading>Edit folder</MainHeading>
+                <H2 title="Folder details" />
+                <p> Fields marked with * are mandatory.</p>
+                <Form onSubmit={handleSubmit(onSubmit)}>
+                  <FormField>
+                    <Input
+                      name="title"
+                      onChange={titleMaxLength.onChange}
+                      id="title"
+                      label="Enter folder title*"
+                      hint="The title of your folder should accurately reflect its content or audience"
+                      inputRef={register({
+                        required: {
+                          value: true,
+                          message: "Title is required",
+                        },
+                        ...titleMaxLength.validation,
+                      })}
+                      error={errors.title?.message}
+                    />
+                    {titleMaxLength.remainingText("title")}
+                  </FormField>
 
-            <FormField>
-              <Textarea
-                name="description"
-                onChange={descriptionMaxLength.onChange}
-                id="description"
-                label="Description"
-                error={errors.description?.message}
-                hint="This is the description as seen by users"
-                inputRef={register(descriptionMaxLength.validation)}
-              />
-              {descriptionMaxLength.remainingText("description")}
-            </FormField>
-            <FormField>
-              <Permissions inputRef={register()} />
-            </FormField>
-            <Button type="submit" name="submitButton">
-              Save and complete
-            </Button>
-            <StyledButton secondary type="button" onClick={backToPreviousPage}>
-              Discard
-            </StyledButton>
-            {errors.server && (
-              <ErrorMessage>{errors.server.message}</ErrorMessage>
+                  <FormField>
+                    <Textarea
+                      name="description"
+                      onChange={descriptionMaxLength.onChange}
+                      id="description"
+                      label="Description"
+                      error={errors.description?.message}
+                      hint="This is the description as seen by users"
+                      inputRef={register(descriptionMaxLength.validation)}
+                    />
+                    {descriptionMaxLength.remainingText("description")}
+                  </FormField>
+                  <FormField>
+                    <Permissions inputRef={register()} />
+                  </FormField>
+                  <Button type="submit" name="submitButton">
+                    Save and complete
+                  </Button>
+                  <StyledButton
+                    secondary
+                    type="button"
+                    onClick={backToPreviousPage}
+                  >
+                    Discard
+                  </StyledButton>
+                  {errors.server && (
+                    <ErrorMessage>{errors.server.message}</ErrorMessage>
+                  )}
+                </Form>
+              </>
+            ) : (
+              <>
+                <ErrorComponent
+                  title="You do not have permission to do this."
+                  description="Please contact a Workspace Administrator to request access
+                to this folder."
+                />
+              </>
             )}
-          </Form>
-        </PageContent>
-      </ContentWrapper>
-      <Footer />
-    </PageLayout>
+          </PageContent>
+        </ContentWrapper>
+        <Footer />
+      </PageLayout>
+    </>
   );
 };
 

--- a/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
@@ -15,7 +15,6 @@ import { Navigation } from "../../../../../components/Navigation";
 import { PageLayout } from "../../../../../components/PageLayout";
 import { Permissions } from "../../../../../components/Permissions";
 import { Textarea } from "../../../../../components/Textarea";
-import { User } from "../../../../../lib/auth";
 import {
   useUpdateFolderMutation,
   useGetFolderByIdQuery,
@@ -61,11 +60,7 @@ interface FolderInputs {
   server?: never;
 }
 
-interface InitialProps {
-  user: User | undefined;
-}
-
-const UpdateFolder: NextPage<InitialProps> = () => {
+const UpdateFolder: NextPage = () => {
   const router = useRouter();
   const { workspaceId, folderId } = router.query;
 

--- a/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/folders/[folderId]/update-folder.tsx
@@ -83,19 +83,20 @@ const UpdateFolder: NextPage<InitialProps> = () => {
 
   const [, updateFolder] = useUpdateFolderMutation();
 
-  const [returnedUser] = useGetWorkspaceMembershipQuery({
+  const [returnedUserPermissons] = useGetWorkspaceMembershipQuery({
     variables: {
       workspaceId,
     },
   });
 
-  const userRole = returnedUser.data?.getWorkspaceMembership;
+  const userRole = returnedUserPermissons.data?.getWorkspaceMembership;
   const folderAccessLevel = folder.data?.folder.roleRequired;
 
   // If the folder only permits workspace members to view, and the user is not
   // a member of the workspace, then set accessPermitted to false.
   const accessPermitted =
-    folderAccessLevel === "WORKSPACE_MEMBER" && userRole === "NON_MEMBER"
+    folderAccessLevel === RoleRequired.WorkspaceMember &&
+    userRole === "NON_MEMBER"
       ? false
       : true;
 
@@ -147,85 +148,83 @@ const UpdateFolder: NextPage<InitialProps> = () => {
   };
 
   return (
-    <>
-      <PageLayout>
-        <NavHeader />
-        <ContentWrapper>
-          <Navigation
-            workspaceId={workspaceId}
-            workspaceTitle={data.workspace.title}
-            activeFolder={folderId}
-          />
-          <PageContent>
-            {accessPermitted ? (
-              <>
-                <MainHeading>Edit folder</MainHeading>
-                <H2 title="Folder details" />
-                <p> Fields marked with * are mandatory.</p>
-                <Form onSubmit={handleSubmit(onSubmit)}>
-                  <FormField>
-                    <Input
-                      name="title"
-                      onChange={titleMaxLength.onChange}
-                      id="title"
-                      label="Enter folder title*"
-                      hint="The title of your folder should accurately reflect its content or audience"
-                      inputRef={register({
-                        required: {
-                          value: true,
-                          message: "Title is required",
-                        },
-                        ...titleMaxLength.validation,
-                      })}
-                      error={errors.title?.message}
-                    />
-                    {titleMaxLength.remainingText("title")}
-                  </FormField>
+    <PageLayout>
+      <NavHeader />
+      <ContentWrapper>
+        <Navigation
+          workspaceId={workspaceId}
+          workspaceTitle={data.workspace.title}
+          activeFolder={folderId}
+        />
+        <PageContent>
+          {accessPermitted ? (
+            <>
+              <MainHeading>Edit folder</MainHeading>
+              <H2 title="Folder details" />
+              <p> Fields marked with * are mandatory.</p>
+              <Form onSubmit={handleSubmit(onSubmit)}>
+                <FormField>
+                  <Input
+                    name="title"
+                    onChange={titleMaxLength.onChange}
+                    id="title"
+                    label="Enter folder title*"
+                    hint="The title of your folder should accurately reflect its content or audience"
+                    inputRef={register({
+                      required: {
+                        value: true,
+                        message: "Title is required",
+                      },
+                      ...titleMaxLength.validation,
+                    })}
+                    error={errors.title?.message}
+                  />
+                  {titleMaxLength.remainingText("title")}
+                </FormField>
 
-                  <FormField>
-                    <Textarea
-                      name="description"
-                      onChange={descriptionMaxLength.onChange}
-                      id="description"
-                      label="Description"
-                      error={errors.description?.message}
-                      hint="This is the description as seen by users"
-                      inputRef={register(descriptionMaxLength.validation)}
-                    />
-                    {descriptionMaxLength.remainingText("description")}
-                  </FormField>
-                  <FormField>
-                    <Permissions inputRef={register()} />
-                  </FormField>
-                  <Button type="submit" name="submitButton">
-                    Save and complete
-                  </Button>
-                  <StyledButton
-                    secondary
-                    type="button"
-                    onClick={backToPreviousPage}
-                  >
-                    Discard
-                  </StyledButton>
-                  {errors.server && (
-                    <ErrorMessage>{errors.server.message}</ErrorMessage>
-                  )}
-                </Form>
-              </>
-            ) : (
-              <>
-                <ErrorComponent
-                  title="You do not have permission to do this."
-                  description="Please contact a Workspace Administrator to request access
+                <FormField>
+                  <Textarea
+                    name="description"
+                    onChange={descriptionMaxLength.onChange}
+                    id="description"
+                    label="Description"
+                    error={errors.description?.message}
+                    hint="This is the description as seen by users"
+                    inputRef={register(descriptionMaxLength.validation)}
+                  />
+                  {descriptionMaxLength.remainingText("description")}
+                </FormField>
+                <FormField>
+                  <Permissions inputRef={register()} />
+                </FormField>
+                <Button type="submit" name="submitButton">
+                  Save and complete
+                </Button>
+                <StyledButton
+                  secondary
+                  type="button"
+                  onClick={backToPreviousPage}
+                >
+                  Discard
+                </StyledButton>
+                {errors.server && (
+                  <ErrorMessage>{errors.server.message}</ErrorMessage>
+                )}
+              </Form>
+            </>
+          ) : (
+            <>
+              <ErrorComponent
+                title="You do not have permission to do this."
+                description="Please contact a Workspace Administrator to request access
                 to this folder."
-                />
-              </>
-            )}
-          </PageContent>
-        </ContentWrapper>
-        <Footer />
-      </PageLayout>
-    </>
+              />
+            </>
+          )}
+        </PageContent>
+      </ContentWrapper>
+      <Footer />
+    </PageLayout>
   );
 };
 

--- a/frontend/pages/workspaces/[workspaceId]/members.graphql
+++ b/frontend/pages/workspaces/[workspaceId]/members.graphql
@@ -18,10 +18,5 @@ query GetWorkspaceWithMembers($id: ID!) {
 }
 
 query GetWorkspaceMembership($workspaceId: ID!) {
-  getWorkspaceMembership(workspaceId: $workspaceId) {
-    id
-    authId
-    name
-    emailAddress
-  }
+  getWorkspaceMembership(workspaceId: $workspaceId)
 }

--- a/frontend/pages/workspaces/[workspaceId]/members.graphql
+++ b/frontend/pages/workspaces/[workspaceId]/members.graphql
@@ -16,3 +16,12 @@ query GetWorkspaceWithMembers($id: ID!) {
     }
   }
 }
+
+query GetWorkspaceMembership($workspaceId: ID!) {
+  getWorkspaceMembership(workspaceId: $workspaceId) {
+    id
+    authId
+    name
+    emailAddress
+  }
+}

--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -1362,8 +1362,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "User",
+                "kind": "ENUM",
+                "name": "NewRole",
                 "ofType": null
               }
             }

--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -418,7 +418,7 @@
               "name": null,
               "ofType": {
                 "kind": "ENUM",
-                "name": "NewRole",
+                "name": "WorkspaceMembership",
                 "ofType": null
               }
             }
@@ -1159,35 +1159,6 @@
       },
       {
         "description": null,
-        "enumValues": [
-          {
-            "deprecationReason": null,
-            "description": "Promote to admin",
-            "isDeprecated": false,
-            "name": "ADMIN"
-          },
-          {
-            "deprecationReason": null,
-            "description": "Add as a non-admin member or demote an admin",
-            "isDeprecated": false,
-            "name": "NON_ADMIN"
-          },
-          {
-            "deprecationReason": null,
-            "description": "Remove member",
-            "isDeprecated": false,
-            "name": "NON_MEMBER"
-          }
-        ],
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "kind": "ENUM",
-        "name": "NewRole",
-        "possibleTypes": null
-      },
-      {
-        "description": null,
         "enumValues": null,
         "fields": null,
         "inputFields": [
@@ -1363,7 +1334,7 @@
               "name": null,
               "ofType": {
                 "kind": "ENUM",
-                "name": "NewRole",
+                "name": "WorkspaceMembership",
                 "ofType": null
               }
             }
@@ -1968,6 +1939,35 @@
         "interfaces": [],
         "kind": "OBJECT",
         "name": "Workspace",
+        "possibleTypes": null
+      },
+      {
+        "description": null,
+        "enumValues": [
+          {
+            "deprecationReason": null,
+            "description": "Promote to admin",
+            "isDeprecated": false,
+            "name": "ADMIN"
+          },
+          {
+            "deprecationReason": null,
+            "description": "Add as a non-admin member or demote an admin",
+            "isDeprecated": false,
+            "name": "NON_ADMIN"
+          },
+          {
+            "deprecationReason": null,
+            "description": "Remove member",
+            "isDeprecated": false,
+            "name": "NON_MEMBER"
+          }
+        ],
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "kind": "ENUM",
+        "name": "WorkspaceMembership",
         "possibleTypes": null
       },
       {

--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -1342,6 +1342,37 @@
               {
                 "defaultValue": null,
                 "description": null,
+                "name": "workspaceId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "getWorkspaceMembership",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [
+              {
+                "defaultValue": null,
+                "description": null,
                 "name": "workspace",
                 "type": {
                   "kind": "NON_NULL",

--- a/workspace-service/src/db/workspaces.rs
+++ b/workspace-service/src/db/workspaces.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::suspicious_else_formatting)]
 
 use crate::db;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use sqlx::{types::Uuid, PgPool};
 use std::fmt::Display;
 #[derive(Clone)]

--- a/workspace-service/src/db/workspaces.rs
+++ b/workspace-service/src/db/workspaces.rs
@@ -122,18 +122,14 @@ impl WorkspaceRepo {
         }
     }
 
-    pub async fn is_member(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<db::User> {
+    pub async fn is_member(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<Role> {
         match db::UserRepo::find_by_id(&user_id, pool).await? {
             Some(user) => {
                 let workspace = WorkspaceRepo::find_by_id(workspace_id, pool).await?;
                 db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
-                Ok(user)
+                Ok(Role::NonAdmin)
             }
-            None => Err(anyhow!(
-                "User {} is not a member of workspace {}",
-                user_id,
-                workspace_id
-            )),
+            None => Ok(Role::NonMember),
         }
     }
 
@@ -234,18 +230,14 @@ impl WorkspaceRepoFake {
         Ok(workspace)
     }
 
-    pub async fn is_member(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<db::User> {
+    pub async fn is_member(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<Role> {
         match db::UserRepo::find_by_id(&user_id, pool).await? {
             Some(user) => {
                 let workspace = WorkspaceRepoFake::find_by_id(workspace_id, pool).await?;
                 db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
-                Ok(user)
+                Ok(Role::NonAdmin)
             }
-            None => Err(anyhow!(
-                "User {} is not a member of workspace {}",
-                user_id,
-                workspace_id
-            )),
+            None => Ok(Role::NonMember),
         }
     }
 

--- a/workspace-service/src/db/workspaces.rs
+++ b/workspace-service/src/db/workspaces.rs
@@ -122,16 +122,16 @@ impl WorkspaceRepo {
         }
     }
 
-    pub async fn is_member(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<Role> {
+    pub async fn get_user_role(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<Role> {
         match db::UserRepo::find_by_id(&user_id, pool).await? {
             Some(user) => {
                 let workspace = WorkspaceRepo::find_by_id(workspace_id, pool).await?;
                 let is_member = db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
                 let is_admin = db::TeamRepo::is_member(workspace.admins, user.id, pool).await?;
-                if is_member {
-                    Ok(Role::NonAdmin)
-                } else if is_admin {
+                if is_admin {
                     Ok(Role::Admin)
+                } else if is_member {
+                    Ok(Role::NonAdmin)
                 } else {
                     Ok(Role::NonMember)
                 }
@@ -237,16 +237,16 @@ impl WorkspaceRepoFake {
         Ok(workspace)
     }
 
-    pub async fn is_member(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<Role> {
+    pub async fn get_user_role(workspace_id: Uuid, user_id: Uuid, pool: &PgPool) -> Result<Role> {
         match db::UserRepo::find_by_id(&user_id, pool).await? {
             Some(user) => {
                 let workspace = WorkspaceRepoFake::find_by_id(workspace_id, pool).await?;
                 let is_member = db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
                 let is_admin = db::TeamRepo::is_member(workspace.admins, user.id, pool).await?;
-                if is_member {
-                    Ok(Role::NonAdmin)
-                } else if is_admin {
+                if is_admin {
                     Ok(Role::Admin)
+                } else if is_member {
+                    Ok(Role::NonAdmin)
                 } else {
                     Ok(Role::NonMember)
                 }

--- a/workspace-service/src/db/workspaces.rs
+++ b/workspace-service/src/db/workspaces.rs
@@ -126,8 +126,15 @@ impl WorkspaceRepo {
         match db::UserRepo::find_by_id(&user_id, pool).await? {
             Some(user) => {
                 let workspace = WorkspaceRepo::find_by_id(workspace_id, pool).await?;
-                db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
-                Ok(Role::NonAdmin)
+                let is_member = db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
+                let is_admin = db::TeamRepo::is_member(workspace.admins, user.id, pool).await?;
+                if is_member {
+                    Ok(Role::NonAdmin)
+                } else if is_admin {
+                    Ok(Role::Admin)
+                } else {
+                    Ok(Role::NonMember)
+                }
             }
             None => Ok(Role::NonMember),
         }
@@ -234,8 +241,15 @@ impl WorkspaceRepoFake {
         match db::UserRepo::find_by_id(&user_id, pool).await? {
             Some(user) => {
                 let workspace = WorkspaceRepoFake::find_by_id(workspace_id, pool).await?;
-                db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
-                Ok(Role::NonAdmin)
+                let is_member = db::TeamRepo::is_member(workspace.members, user.id, pool).await?;
+                let is_admin = db::TeamRepo::is_member(workspace.admins, user.id, pool).await?;
+                if is_member {
+                    Ok(Role::NonAdmin)
+                } else if is_admin {
+                    Ok(Role::Admin)
+                } else {
+                    Ok(Role::NonMember)
+                }
             }
             None => Ok(Role::NonMember),
         }

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -298,9 +298,9 @@ async fn get_workspace_membership(
         .await?
         .ok_or_else(|| anyhow::anyhow!("user not found"))?;
 
-    let userRole = WorkspaceRepo::is_member(workspace_id, user.id, pool).await?;
+    let user_role = WorkspaceRepo::is_member(workspace_id, user.id, pool).await?;
 
-    Ok(userRole.into())
+    Ok(user_role.into())
 }
 
 async fn change_workspace_membership(

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -163,7 +163,7 @@ impl WorkspacesQuery {
     ) -> FieldResult<NewRole> {
         let requesting_user = context.data()?;
         let pool = context.data()?;
-        let event_client: &EventClient = context.data()?;
+        let event_client = context.data()?;
 
         get_workspace_membership(
             workspace_id.try_into()?,
@@ -292,7 +292,7 @@ async fn get_workspace_membership(
     workspace_id: Uuid,
     requesting_user: &RequestingUser,
     pool: &PgPool,
-    event_client: &EventClient,
+    _event_client: &EventClient,
 ) -> FieldResult<NewRole> {
     let user = db::UserRepo::find_by_auth_id(&requesting_user.auth_id, pool)
         .await?


### PR DESCRIPTION
![Screenshot 2020-11-11 at 09 00 23](https://user-images.githubusercontent.com/22911872/98795542-3b65e480-2402-11eb-86bf-55461e5eeb1e.png)

- Ticket: [AB#1818](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1818)

## Acceptance criteria

- Workspace Service has a query that informs us of whether or not a given user is a member of a workspace.

- The frontend can render an error component when a user doesn't have sufficient permissions to access or edit a folder.

## Pre-review checklist

- [x] Tests
- [x] Documentation
- [x] Analytics (user analytics, e.g. Google Analytics)
- [x] Observability (metrics/tracing)
- [ ] ~~Feature flag~~
- [x] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Test plan?

1. Change the permissions on a folder to be 'workspace members', by navigating to it's edit page and selecting 'Make visible to all members of this workspace' from the permissions section. Save the changes. grab the folder URL for later. 
2. Using tablePlus or similar, access the local DB.
3. Grab the ID of a user who belongs to the workspace you've just updated a folder in.
4. Run the local workspace service with `make run-local` and navigate to http://localhost:3030/graphiql.
5. Run the below query, using the workspace ID from the folder URL, and the user ID of the user from 2 steps above. In addition, add the following to the headers section in the bottom right `{ "x-user-auth-id": "feedface-0000-0000-0000-000000000000"}`.

```graphql
mutation {
  changeWorkspaceMembership(
    input: {
      workspace: [workspace id here]
      user: [user id here]
      newRole: NON_ADMIN
    }
  ) {
    id
    title
    admins: members(filter: ADMIN) {name, id}
    members: members(filter: NON_ADMIN) {name, id}
  }
}
```

6. In the frontend, logout with `localhost:3000/auth/logout`.
7. In the file `noop-passport-strategy.js`, change lines 15-17 to reflect the details of the user who's ID you used in the above query. 
8. Log back in with `localhost:3000/auth/login`. You are now authenticated with the user that has insufficient access permissions for the folder edited earlier.
9. Navigate to the folder URL from step 1. You should see an error.

## Test checklist

- [x] Tested locally

- Platforms/Browsers:

  - [x] Google Chrome (latest version)
  - [x] Internet Explorer 11
  - [x] Edge

- Accessibility:

  - [x] Screen Reader
  - [x] Keyboard Navigation
  - [x] Magnification
  - [x] Contrast
  - [x] Text size 200%
  - [x] Touch target areas (Mobile)
  - [x] Landscape (Mobile)

![](https://media.giphy.com/media/xT8qBcsMQwZTvkxFnO/giphy.gif)