### PR TITLE
Record node error as attribute

### DIFF
--- a/frontend/lib/server/reportError.js
+++ b/frontend/lib/server/reportError.js
@@ -11,6 +11,10 @@ const reportError = (err) => {
 
   if (span) {
     span.recordException(err);
+
+    // The ApplicationInsights exporter doesn't currently export events. So we
+    // also record this error as an attribute.
+    span.setAttribute("exception", err.message);
   } else {
     console.log("Cannot report error, because no current span.", err);
   }


### PR DESCRIPTION
The App Insights exporter doesn't export events at the moment. So this reports errors as attributes on the current span.
