### PR TITLE
Make admin mutation

### DIFF
--- a/frontend/components/Members/MemberStatusButtonCell.test.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.test.tsx
@@ -18,8 +18,8 @@ const user = {
 const buttonCellProps = {
   workspaceId: "id",
   changeMembership: (() => {}) as any,
-  mutatationError: null,
-  setMutatationError: (() => {}) as any,
+  mutationError: null,
+  setMutationError: (() => {}) as any,
   user,
   newRole: WorkspaceMembership.Admin,
 };
@@ -54,7 +54,7 @@ test("renders error message when user matches one in error", () => {
       <MemberStatusButtonCell
         {...buttonCellProps}
         newRole={WorkspaceMembership.Admin}
-        mutatationError={{ user, error: "something went wrong" }}
+        mutationError={{ user, error: "something went wrong" }}
       />
     </ThemeProvider>
   );
@@ -68,7 +68,7 @@ test("renders no error message when user does not match error", () => {
       <MemberStatusButtonCell
         {...buttonCellProps}
         newRole={WorkspaceMembership.Admin}
-        mutatationError={{
+        mutationError={{
           user: { ...user, id: "someone-else" },
           error: "something went wrong",
         }}

--- a/frontend/components/Members/MemberStatusButtonCell.test.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+
+import { render } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+
+import theme from "../../lib/fixtures/theme.json";
+import { WorkspaceMembership } from "../../lib/generated/graphql";
+import { MemberStatusButtonCell } from "./MemberStatusButtonCell";
+
+const user = {
+  id: "asdf",
+  authId: "ghjkl",
+  name: "Mr T",
+  emailAddress: "t@t.com",
+  isPlatformAdmin: false,
+};
+
+const buttonCellProps = {
+  workspaceId: "id",
+  changeMembership: (() => {}) as any,
+  mutatationError: null,
+  setMutatationError: (() => {}) as any,
+  user,
+  newRole: WorkspaceMembership.Admin,
+};
+
+test("renders make admin button", () => {
+  const { asFragment } = render(
+    <MemberStatusButtonCell
+      {...buttonCellProps}
+      newRole={WorkspaceMembership.Admin}
+    />
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("renders make member button", () => {
+  const { asFragment } = render(
+    <ThemeProvider theme={theme}>
+      <MemberStatusButtonCell
+        {...buttonCellProps}
+        newRole={WorkspaceMembership.Admin}
+      />
+    </ThemeProvider>
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("renders error message when user matches one in error", () => {
+  const { asFragment } = render(
+    <ThemeProvider theme={theme}>
+      <MemberStatusButtonCell
+        {...buttonCellProps}
+        newRole={WorkspaceMembership.Admin}
+        mutatationError={{ user, error: "something went wrong" }}
+      />
+    </ThemeProvider>
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("renders no error message when user does not match error", () => {
+  const { asFragment } = render(
+    <ThemeProvider theme={theme}>
+      <MemberStatusButtonCell
+        {...buttonCellProps}
+        newRole={WorkspaceMembership.Admin}
+        mutatationError={{
+          user: { ...user, id: "someone-else" },
+          error: "something went wrong",
+        }}
+      />
+    </ThemeProvider>
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/frontend/components/Members/MemberStatusButtonCell.test.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.test.tsx
@@ -40,7 +40,7 @@ test("renders make member button", () => {
     <ThemeProvider theme={theme}>
       <MemberStatusButtonCell
         {...buttonCellProps}
-        newRole={WorkspaceMembership.Admin}
+        newRole={WorkspaceMembership.NonAdmin}
       />
     </ThemeProvider>
   );

--- a/frontend/components/Members/MemberStatusButtonCell.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.tsx
@@ -1,0 +1,68 @@
+import React, { FC } from "react";
+
+import { Button } from "nhsuk-react-components";
+import { OperationContext, OperationResult } from "urql";
+
+import {
+  User,
+  WorkspaceMembership,
+  MembershipChange,
+  Exact,
+  ChangeWorkspaceMembershipMutation,
+} from "../../lib/generated/graphql";
+
+type MutationError = {
+  user: User;
+  error?: string | undefined;
+} | null;
+
+type ButtonCellProps = {
+  user: User;
+  workspaceId: string;
+  newRole: WorkspaceMembership;
+  changeMembership: (
+    variables?:
+      | Exact<{
+          input: MembershipChange;
+        }>
+      | undefined,
+    context?: Partial<OperationContext> | undefined
+  ) => Promise<OperationResult<ChangeWorkspaceMembershipMutation>>;
+  mutatationError: MutationError;
+  setMutatationError: React.Dispatch<React.SetStateAction<MutationError>>;
+};
+
+export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
+  user,
+  workspaceId,
+  newRole,
+  changeMembership,
+  setMutatationError,
+  mutatationError,
+}) => (
+  <>
+    <Button
+      secondary
+      onClick={async () => {
+        const result = await changeMembership({
+          input: {
+            workspace: workspaceId,
+            user: user.id,
+            newRole,
+          },
+        });
+        setMutatationError({
+          user,
+          error: result.error?.message,
+        });
+      }}
+    >
+      {newRole === WorkspaceMembership.Admin
+        ? "Make Administrator"
+        : "Make Member"}
+    </Button>
+    {mutatationError?.user.id === user.id && mutatationError?.error && (
+      <p> Oh no... {mutatationError.error} </p>
+    )}
+  </>
+);

--- a/frontend/components/Members/MemberStatusButtonCell.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.tsx
@@ -28,8 +28,8 @@ type ButtonCellProps = {
       | undefined,
     context?: Partial<OperationContext> | undefined
   ) => Promise<OperationResult<ChangeWorkspaceMembershipMutation>>;
-  mutatationError: MutationError;
-  setMutatationError: React.Dispatch<React.SetStateAction<MutationError>>;
+  mutationError: MutationError;
+  setMutationError: React.Dispatch<React.SetStateAction<MutationError>>;
 };
 
 export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
@@ -37,8 +37,8 @@ export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
   workspaceId,
   newRole,
   changeMembership,
-  setMutatationError,
-  mutatationError,
+  setMutationError,
+  mutationError,
 }) => (
   <>
     <Button
@@ -51,7 +51,7 @@ export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
             newRole,
           },
         });
-        setMutatationError({
+        setMutationError({
           user,
           error: result.error?.message,
         });
@@ -61,8 +61,8 @@ export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
         ? "Make Administrator"
         : "Make Member"}
     </Button>
-    {mutatationError?.user.id === user.id && mutatationError?.error && (
-      <p> Oh no... {mutatationError.error} </p>
+    {mutationError?.user.id === user.id && mutationError?.error && (
+      <p> Oh no... {mutationError.error} </p>
     )}
   </>
 );

--- a/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
+++ b/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders error message when user matches one in error 1`] = `
+<DocumentFragment>
+  <button
+    aria-disabled="false"
+    class="nhsuk-button nhsuk-button--secondary"
+    type="submit"
+  >
+    Make Administrator
+  </button>
+  <p>
+     Oh no... something went wrong 
+  </p>
+</DocumentFragment>
+`;
+
+exports[`renders make admin button 1`] = `
+<DocumentFragment>
+  <button
+    aria-disabled="false"
+    class="nhsuk-button nhsuk-button--secondary"
+    type="submit"
+  >
+    Make Administrator
+  </button>
+</DocumentFragment>
+`;
+
+exports[`renders make member button 1`] = `
+<DocumentFragment>
+  <button
+    aria-disabled="false"
+    class="nhsuk-button nhsuk-button--secondary"
+    type="submit"
+  >
+    Make Administrator
+  </button>
+</DocumentFragment>
+`;
+
+exports[`renders no error message when user does not match error 1`] = `
+<DocumentFragment>
+  <button
+    aria-disabled="false"
+    class="nhsuk-button nhsuk-button--secondary"
+    type="submit"
+  >
+    Make Administrator
+  </button>
+</DocumentFragment>
+`;

--- a/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
+++ b/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders make member button 1`] = `
     class="nhsuk-button nhsuk-button--secondary"
     type="submit"
   >
-    Make Administrator
+    Make Member
   </button>
 </DocumentFragment>
 `;

--- a/frontend/components/Members/index.tsx
+++ b/frontend/components/Members/index.tsx
@@ -1,0 +1,1 @@
+export { MemberStatusButtonCell } from "./MemberStatusButtonCell";

--- a/frontend/pages/workspaces/[workspaceId]/members.graphql
+++ b/frontend/pages/workspaces/[workspaceId]/members.graphql
@@ -20,3 +20,18 @@ query GetWorkspaceWithMembers($id: ID!) {
 query GetWorkspaceMembership($workspaceId: ID!) {
   getWorkspaceMembership(workspaceId: $workspaceId)
 }
+
+mutation ChangeWorkspaceMembership($input: MembershipChange!) {
+  changeWorkspaceMembership(input: $input) {
+    id
+    title
+    admins: members(filter: ADMIN) {
+      name
+      id
+    }
+    members: members(filter: NON_ADMIN) {
+      name
+      id
+    }
+  }
+}

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -2,12 +2,12 @@ import React, { FC, useState } from "react";
 
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { Button } from "nhsuk-react-components";
 import styled from "styled-components";
 
 import { Footer } from "../../../components/Footer";
 import { Head } from "../../../components/Head";
 import { MainHeading } from "../../../components/MainHeading";
+import { MemberStatusButtonCell } from "../../../components/Members";
 import { NavHeader } from "../../../components/NavHeader";
 import { Navigation } from "../../../components/Navigation";
 import { PageLayout } from "../../../components/PageLayout";
@@ -66,6 +66,25 @@ const WorkspaceMembersPage: NextPage = () => {
     error?: string;
   } | null>(null);
 
+  const buttonCellProps = {
+    workspaceId: id,
+    changeMembership,
+    mutatationError,
+    setMutatationError,
+  };
+  const makeAdminButtonCell = (user: User) =>
+    MemberStatusButtonCell({
+      ...buttonCellProps,
+      user,
+      newRole: WorkspaceMembership.Admin,
+    });
+  const makeNonAdminButtonCell = (user: User) =>
+    MemberStatusButtonCell({
+      ...buttonCellProps,
+      user,
+      newRole: WorkspaceMembership.NonAdmin,
+    });
+
   const workspaceTitle = (!fetching && data?.workspace.title) || "Loading...";
 
   return (
@@ -107,33 +126,7 @@ const WorkspaceMembersPage: NextPage = () => {
                         ),
                       },
                       {
-                        // eslint-disable-next-line react/display-name
-                        content: (user) => (
-                          <>
-                            <Button
-                              secondary
-                              onClick={async () => {
-                                const result = await changeMembership({
-                                  input: {
-                                    workspace: id,
-                                    user: user.id,
-                                    newRole: WorkspaceMembership.NonAdmin,
-                                  },
-                                });
-                                setMutatationError({
-                                  user,
-                                  error: result.error?.message,
-                                });
-                              }}
-                            >
-                              Make Member
-                            </Button>
-                            {mutatationError?.user.id === user.id &&
-                              mutatationError?.error && (
-                                <p> Oh no... {mutatationError.error} </p>
-                              )}
-                          </>
-                        ),
+                        content: makeAdminButtonCell,
                       },
                     ]}
                     data={data.workspace.admins as User[]}
@@ -164,29 +157,7 @@ const WorkspaceMembersPage: NextPage = () => {
                         ),
                       },
                       {
-                        // eslint-disable-next-line react/display-name
-                        content: (user) => (
-                          <>
-                            <Button
-                              secondary
-                              onClick={() =>
-                                changeMembership({
-                                  input: {
-                                    workspace: id,
-                                    user: user.id,
-                                    newRole: WorkspaceMembership.Admin,
-                                  },
-                                })
-                              }
-                            >
-                              Make Administrator
-                            </Button>
-                            {mutatationError?.user.id === user.id &&
-                              mutatationError?.error && (
-                                <p> Oh no... {mutatationError.error} </p>
-                              )}
-                          </>
-                        ),
+                        content: makeNonAdminButtonCell,
                       },
                     ]}
                     data={data.workspace.members as User[]}

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -120,8 +120,8 @@ const WorkspaceMembersPage: NextPage = () => {
                         // eslint-disable-next-line react/display-name
                         content: () => (
                           <>
-                            Administrators can manager folder, members and
-                            workspace details
+                            Members cannot manage members, folders, and
+                            workspace details.
                           </>
                         ),
                       },

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -15,6 +15,8 @@ import { ResponsiveTable } from "../../../components/Table";
 import {
   User,
   useGetWorkspaceWithMembersQuery,
+  useChangeWorkspaceMembershipMutation,
+  WorkspaceMembership,
 } from "../../../lib/generated/graphql";
 import withUrqlClient from "../../../lib/withUrqlClient";
 
@@ -58,6 +60,8 @@ const WorkspaceMembersPage: NextPage = () => {
     variables: { id },
   });
 
+  const [, changeMembership] = useChangeWorkspaceMembershipMutation();
+
   const workspaceTitle = (!fetching && data?.workspace.title) || "Loading...";
 
   return (
@@ -100,9 +104,22 @@ const WorkspaceMembersPage: NextPage = () => {
                       },
                       {
                         // eslint-disable-next-line react/display-name
-                        content: () => (
+                        content: (user) => (
                           <>
-                            <Button secondary>Make Member</Button>
+                            <Button
+                              secondary
+                              onClick={() =>
+                                changeMembership({
+                                  input: {
+                                    workspace: id,
+                                    user: user.id,
+                                    newRole: WorkspaceMembership.NonAdmin,
+                                  },
+                                })
+                              }
+                            >
+                              Make Member
+                            </Button>
                           </>
                         ),
                       },
@@ -136,9 +153,22 @@ const WorkspaceMembersPage: NextPage = () => {
                       },
                       {
                         // eslint-disable-next-line react/display-name
-                        content: () => (
+                        content: (user) => (
                           <>
-                            <Button secondary>Make Administrator</Button>
+                            <Button
+                              secondary
+                              onClick={() =>
+                                changeMembership({
+                                  input: {
+                                    workspace: id,
+                                    user: user.id,
+                                    newRole: WorkspaceMembership.Admin,
+                                  },
+                                })
+                              }
+                            >
+                              Make Administrator
+                            </Button>
                           </>
                         ),
                       },

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 
 import { NextPage } from "next";
 import { useRouter } from "next/router";
@@ -61,6 +61,10 @@ const WorkspaceMembersPage: NextPage = () => {
   });
 
   const [, changeMembership] = useChangeWorkspaceMembershipMutation();
+  const [mutatationError, setMutatationError] = useState<{
+    user: User;
+    error?: string;
+  } | null>(null);
 
   const workspaceTitle = (!fetching && data?.workspace.title) || "Loading...";
 
@@ -108,18 +112,26 @@ const WorkspaceMembersPage: NextPage = () => {
                           <>
                             <Button
                               secondary
-                              onClick={() =>
-                                changeMembership({
+                              onClick={async () => {
+                                const result = await changeMembership({
                                   input: {
                                     workspace: id,
                                     user: user.id,
                                     newRole: WorkspaceMembership.NonAdmin,
                                   },
-                                })
-                              }
+                                });
+                                setMutatationError({
+                                  user,
+                                  error: result.error?.message,
+                                });
+                              }}
                             >
                               Make Member
                             </Button>
+                            {mutatationError?.user.id === user.id &&
+                              mutatationError?.error && (
+                                <p> Oh no... {mutatationError.error} </p>
+                              )}
                           </>
                         ),
                       },
@@ -169,6 +181,10 @@ const WorkspaceMembersPage: NextPage = () => {
                             >
                               Make Administrator
                             </Button>
+                            {mutatationError?.user.id === user.id &&
+                              mutatationError?.error && (
+                                <p> Oh no... {mutatationError.error} </p>
+                              )}
                           </>
                         ),
                       },

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -61,7 +61,7 @@ const WorkspaceMembersPage: NextPage = () => {
   });
 
   const [, changeMembership] = useChangeWorkspaceMembershipMutation();
-  const [mutatationError, setMutatationError] = useState<{
+  const [mutationError, setMutationError] = useState<{
     user: User;
     error?: string;
   } | null>(null);
@@ -69,8 +69,8 @@ const WorkspaceMembersPage: NextPage = () => {
   const buttonCellProps = {
     workspaceId: id,
     changeMembership,
-    mutatationError,
-    setMutatationError,
+    mutationError,
+    setMutationError,
   };
   const makeAdminButtonCell = (user: User) =>
     MemberStatusButtonCell({
@@ -120,8 +120,8 @@ const WorkspaceMembersPage: NextPage = () => {
                         // eslint-disable-next-line react/display-name
                         content: () => (
                           <>
-                            Members cannot manage members, folders, and
-                            workspace details.
+                            Administrators can manager folder, members and
+                            workspace details
                           </>
                         ),
                       },

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -126,7 +126,7 @@ const WorkspaceMembersPage: NextPage = () => {
                         ),
                       },
                       {
-                        content: makeAdminButtonCell,
+                        content: makeNonAdminButtonCell,
                       },
                     ]}
                     data={data.workspace.admins as User[]}
@@ -157,7 +157,7 @@ const WorkspaceMembersPage: NextPage = () => {
                         ),
                       },
                       {
-                        content: makeNonAdminButtonCell,
+                        content: makeAdminButtonCell,
                       },
                     ]}
                     data={data.workspace.members as User[]}

--- a/workspace-service/src/graphql/workspaces.rs
+++ b/workspace-service/src/graphql/workspaces.rs
@@ -317,7 +317,7 @@ async fn change_workspace_membership(
         .into());
     }
 
-    if user.id == user_id {
+    if !user.is_platform_admin && user.id == user_id {
         return Err(anyhow::anyhow!(
             "user with auth_id {} cannot demote themselves to {}",
             user.auth_id,


### PR DESCRIPTION
![](https://media.giphy.com/media/139lMwJ9ow7bKE/giphy.gif)


- [x] display error if someone tries to demote themselves and are not platform admin (proper styling for this will come as a separate PR)
~- [ ] fix horizontal width jank~ will come as a separate PR


- Ticket: [AB#1820](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1820)
- Design: https://www.figma.com/file/tYFsqhG61CleWS1tUapAar/Source-of-Truth-UI?node-id=835%3A9046

## Acceptance criteria

## Pre-review checklist

- [x] Tests

~- [ ] Feature flag~ hiding for non-admins comes as a separate PR

## Testing information

- you can become a non-site-admin by editing line 15 of frontend/lib/server/noop-passport-strategy.js from
```
    const testAuthId = "feedface-0000-0000-0000-000000000000";
```
to the auth_id of some other user.

## Test checklist

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)
  - [ ] Internet Explorer 11
  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader
  - [ ] Keyboard Navigation
  - [ ] Magnification
  - [ ] Contrast
  - [ ] Text size 200%
  - [ ] Touch target areas (Mobile)
  - [ ] Landscape (Mobile)
