### PR TITLE
CSS FIXES: Expander table width and email length 

### DIFF
--- a/frontend/components/Table/Table.tsx
+++ b/frontend/components/Table/Table.tsx
@@ -19,6 +19,19 @@ const TableContainer = styled.div`
       background: ${theme.colorNhsukGrey5};
   `}
   }
+  &.have-expander {
+    table {
+      table-layout: fixed;
+      border-collapse: collapse;
+      width: 100%;
+    }
+    th:first-child {
+      width: 160px;
+    }
+    th:last-child {
+      width: 50px;
+    }
+  }
 `;
 
 const IconWrapper = styled.div`
@@ -90,7 +103,11 @@ const TableComponent = <ItemType extends Item>({
 }: Props<ItemType>) => {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   return (
-    <TableContainer>
+    <TableContainer
+      className={classNames({
+        "have-expander": Boolean(extraDetails),
+      })}
+    >
       <NHSTable.Panel heading={tableHeading}>
         <StyledTable>
           <NHSTable.Head>

--- a/frontend/components/Table/Table.tsx
+++ b/frontend/components/Table/Table.tsx
@@ -19,18 +19,17 @@ const TableContainer = styled.div`
       background: ${theme.colorNhsukGrey5};
   `}
   }
-  &.have-expander {
-    table {
-      table-layout: fixed;
-      border-collapse: collapse;
-      width: 100%;
-    }
-    th:first-child {
-      width: 160px;
-    }
-    th:last-child {
-      width: 50px;
-    }
+
+  table {
+    table-layout: fixed;
+    border-collapse: collapse;
+    width: 100%;
+  }
+  th:first-child {
+    width: 30%;
+  }
+  th:last-child {
+    width: 10%;
   }
 `;
 
@@ -52,6 +51,9 @@ const StyledTable = styled(NHSTable)`
 `;
 
 const ContentCell = styled(NHSTable.Cell)`
+  a[href^="mailto"] {
+    word-break: break-all;
+  }
   &.withoutBottomBorder {
     border-bottom: none;
   }
@@ -103,11 +105,7 @@ const TableComponent = <ItemType extends Item>({
 }: Props<ItemType>) => {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   return (
-    <TableContainer
-      className={classNames({
-        "have-expander": Boolean(extraDetails),
-      })}
-    >
+    <TableContainer>
       <NHSTable.Panel heading={tableHeading}>
         <StyledTable>
           <NHSTable.Head>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17128906/99093705-c0035f00-25ca-11eb-9655-e46c95c56202.png)


This PR

- Fixes the jump in table when you click the expander button. It was originally caused by unfixed width sizes
- introduced `work-break: break-all` to accommodate for long emails and make sure it wraps around properly 

- Ticket: [AB#1820](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1820)
- Design: link to Figma




![Screenshot 2020-11-13 at 09 39 15](https://user-images.githubusercontent.com/254647/99057745-1f924800-2594-11eb-8fed-2c6fb732dd87.png)
![Screenshot 2020-11-13 at 09 39 05](https://user-images.githubusercontent.com/254647/99057754-20c37500-2594-11eb-965d-3fd3b56e9acd.png)

Things to think about:

- [ ] email addresses do funky things at certain screen widths

![Screenshot 2020-11-13 at 09 39 56](https://user-images.githubusercontent.com/254647/99057851-3df84380-2594-11eb-9276-879ff0ff7651.png)


- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)
  - [ ] Internet Explorer 11
  - [ ] Edge
