### PR TITLE
useRequestingUserWorkspaceRights() -> ADMIN if is_platform_admin

### DIFF
--- a/frontend/pages/workspaces/[workspaceId]/members.graphql
+++ b/frontend/pages/workspaces/[workspaceId]/members.graphql
@@ -17,8 +17,8 @@ query GetWorkspaceWithMembers($id: ID!) {
   }
 }
 
-query GetWorkspaceMembership($workspaceId: ID!) {
-  getWorkspaceMembership(workspaceId: $workspaceId)
+query RequestingUserWorkspaceRights($workspaceId: ID!) {
+  requestingUserWorkspaceRights(workspaceId: $workspaceId)
 }
 
 mutation ChangeWorkspaceMembership($input: MembershipChange!) {

--- a/workspace-service/graphql-schema.json
+++ b/workspace-service/graphql-schema.json
@@ -1328,7 +1328,7 @@
             "deprecationReason": null,
             "description": null,
             "isDeprecated": false,
-            "name": "getWorkspaceMembership",
+            "name": "requestingUserWorkspaceRights",
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/workspace-service/src/graphql/folders.rs
+++ b/workspace-service/src/graphql/folders.rs
@@ -1,5 +1,5 @@
 use super::{db, RequestingUser};
-use crate::graphql::workspaces::{get_workspace_membership, WorkspaceMembership};
+use crate::graphql::workspaces::{requesting_user_workspace_rights, WorkspaceMembership};
 use async_graphql::{
     Context, Enum, Error, ErrorExtensions, FieldResult, InputObject, Object, SimpleObject, ID,
 };
@@ -112,9 +112,11 @@ impl FoldersQuery {
         let requesting_user = context.data()?;
         let event_client: &EventClient = context.data()?;
         let folder = db::FolderRepo::find_by_id(id, pool).await?;
-        let user_role =
-            get_workspace_membership(folder.workspace, requesting_user, pool, event_client).await?;
-        if folder.role_required == "WORKSPACE_MEMBER" && user_role == WorkspaceMembership::NonMember
+        let user_rights =
+            requesting_user_workspace_rights(folder.workspace, requesting_user, pool, event_client)
+                .await?;
+        if folder.role_required == "WORKSPACE_MEMBER"
+            && user_rights == WorkspaceMembership::NonMember
         {
             Err(Error::new("Insufficient permissions: access denied")
                 .extend_with(|_, e| e.set("details", "ACCESS_DENIED")))


### PR DESCRIPTION
This also gives platform admins view permission to *all* folders, as a side-effect. I feel like this is what is intended anyway?

Also includes a top-level makefile so `make graphql-schema-update` works without me having to think too much.

- [ ] tests ... yeah. I haven't written any tests for this.
- [ ] Tested locally


![](https://media.giphy.com/media/3oriNWWcEJJn5K3LbO/giphy.gif)