### PR TITLE
error extensions for when you can't edit permissions

### DIFF
--- a/frontend/components/Members/MemberStatusButtonCell.test.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.test.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import { render } from "@testing-library/react";
+import { GraphQLError } from "graphql";
 import { ThemeProvider } from "styled-components";
 import { CombinedError } from "urql";
 
 import theme from "../../lib/fixtures/theme.json";
 import { WorkspaceMembership } from "../../lib/generated/graphql";
 import { MemberStatusButtonCell } from "./MemberStatusButtonCell";
-import { GraphQLError } from "graphql";
 
 const user = {
   id: "asdf",

--- a/frontend/components/Members/MemberStatusButtonCell.test.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.test.tsx
@@ -2,10 +2,12 @@ import React from "react";
 
 import { render } from "@testing-library/react";
 import { ThemeProvider } from "styled-components";
+import { CombinedError } from "urql";
 
 import theme from "../../lib/fixtures/theme.json";
 import { WorkspaceMembership } from "../../lib/generated/graphql";
 import { MemberStatusButtonCell } from "./MemberStatusButtonCell";
+import { GraphQLError } from "graphql";
 
 const user = {
   id: "asdf",
@@ -24,6 +26,8 @@ const buttonCellProps = {
   newRole: WorkspaceMembership.Admin,
   isAdmin: true,
 };
+
+const error: CombinedError = { name: "", message: "", graphQLErrors: [] };
 
 test("renders make admin button", () => {
   const { asFragment } = render(
@@ -79,7 +83,7 @@ test("renders error message when user matches one in error", () => {
       <MemberStatusButtonCell
         {...buttonCellProps}
         newRole={WorkspaceMembership.Admin}
-        mutationError={{ user, error: "something went wrong" }}
+        mutationError={{ user, error }}
       />
     </ThemeProvider>
   );
@@ -87,6 +91,27 @@ test("renders error message when user matches one in error", () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
+test("specific error message when it exists", () => {
+  const specificError: CombinedError = {
+    ...error,
+    graphQLErrors: [
+      ({
+        extensions: { problem: "I don't like you.", suggestion: "Go away." },
+      } as unknown) as GraphQLError,
+    ],
+  };
+  const { asFragment } = render(
+    <ThemeProvider theme={theme}>
+      <MemberStatusButtonCell
+        {...buttonCellProps}
+        newRole={WorkspaceMembership.Admin}
+        mutationError={{ user, error: specificError }}
+      />
+    </ThemeProvider>
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
 test("renders no error message when user does not match error", () => {
   const { asFragment } = render(
     <ThemeProvider theme={theme}>
@@ -95,7 +120,7 @@ test("renders no error message when user does not match error", () => {
         newRole={WorkspaceMembership.Admin}
         mutationError={{
           user: { ...user, id: "someone-else" },
-          error: "something went wrong",
+          error,
         }}
       />
     </ThemeProvider>

--- a/frontend/components/Members/MemberStatusButtonCell.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 
 import { Button } from "nhsuk-react-components";
-import { OperationContext, OperationResult } from "urql";
+import { CombinedError, OperationContext, OperationResult } from "urql";
 
 import {
   User,
@@ -13,7 +13,7 @@ import {
 
 type MutationError = {
   user: User;
-  error?: string | undefined;
+  error?: CombinedError;
 } | null;
 
 type ButtonCellProps = {
@@ -56,7 +56,7 @@ export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
           });
           setMutationError({
             user,
-            error: result.error?.message,
+            error: result.error,
           });
         }}
       >
@@ -65,8 +65,8 @@ export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
           : "Make Member"}
       </Button>
     )}
-    {mutationError?.user.id === user.id && mutationError?.error && (
-      <p> Oh no... {mutationError.error} </p>
+    {mutationError?.user.id === user.id && mutationError?.error?.message && (
+      <p> Oh no... {mutationError.error?.message} </p>
     )}
   </>
 );

--- a/frontend/components/Members/MemberStatusButtonCell.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.tsx
@@ -45,7 +45,6 @@ const StyledButton = styled(Button)`
 const unpackError = (
   error: CombinedError
 ): { problem: string; suggestion: string } => {
-  console.log(error);
   const extensions = error.graphQLErrors[0]?.extensions;
 
   if (!extensions || !extensions.problem || !extensions.suggestion) {

--- a/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
+++ b/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
@@ -6,24 +6,46 @@ exports[`does not render make member button when isAdmin status is false 1`] = `
 
 exports[`renders error message when user matches one in error 1`] = `
 <DocumentFragment>
-  <button
+  .c0 {
+  margin-bottom: 20px;
+}
+
+<button
     aria-disabled="false"
-    class="nhsuk-button nhsuk-button--secondary"
+    class="nhsuk-button nhsuk-button--secondary c0"
     type="submit"
   >
     Make Administrator
   </button>
-  <p>
-     Oh no... something went wrong 
-  </p>
+  .c0 {
+  margin-bottom: 0;
+}
+
+<span
+    class="nhsuk-error-message c0"
+    role="alert"
+  >
+    <span
+      class="nhsuk-u-visually-hidden"
+    >
+      Error: 
+    </span>
+    Something went wrong.
+    <br />
+    Try again.
+  </span>
 </DocumentFragment>
 `;
 
 exports[`renders make admin button 1`] = `
 <DocumentFragment>
-  <button
+  .c0 {
+  margin-bottom: 20px;
+}
+
+<button
     aria-disabled="false"
-    class="nhsuk-button nhsuk-button--secondary"
+    class="nhsuk-button nhsuk-button--secondary c0"
     type="submit"
   >
     Make Administrator
@@ -33,9 +55,13 @@ exports[`renders make admin button 1`] = `
 
 exports[`renders make member button 1`] = `
 <DocumentFragment>
-  <button
+  .c0 {
+  margin-bottom: 20px;
+}
+
+<button
     aria-disabled="false"
-    class="nhsuk-button nhsuk-button--secondary"
+    class="nhsuk-button nhsuk-button--secondary c0"
     type="submit"
   >
     Make Member
@@ -45,12 +71,49 @@ exports[`renders make member button 1`] = `
 
 exports[`renders no error message when user does not match error 1`] = `
 <DocumentFragment>
-  <button
+  .c0 {
+  margin-bottom: 20px;
+}
+
+<button
     aria-disabled="false"
-    class="nhsuk-button nhsuk-button--secondary"
+    class="nhsuk-button nhsuk-button--secondary c0"
     type="submit"
   >
     Make Administrator
   </button>
+</DocumentFragment>
+`;
+
+exports[`specific error message when it exists 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin-bottom: 20px;
+}
+
+<button
+    aria-disabled="false"
+    class="nhsuk-button nhsuk-button--secondary c0"
+    type="submit"
+  >
+    Make Administrator
+  </button>
+  .c0 {
+  margin-bottom: 0;
+}
+
+<span
+    class="nhsuk-error-message c0"
+    role="alert"
+  >
+    <span
+      class="nhsuk-u-visually-hidden"
+    >
+      Error: 
+    </span>
+    I don't like you.
+    <br />
+    Go away.
+  </span>
 </DocumentFragment>
 `;

--- a/frontend/cypress/fixtures/requesting-user-workspace-rights.json
+++ b/frontend/cypress/fixtures/requesting-user-workspace-rights.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "requestingUserWorkspaceRights": "ADMIN"
+  }
+}

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -3,6 +3,7 @@ import React, { FC, useState } from "react";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import styled from "styled-components";
+import { CombinedError } from "urql";
 
 import { EmailLink } from "../../../components/EmailLink";
 import { Footer } from "../../../components/Footer";
@@ -21,7 +22,6 @@ import {
   useRequestingUserWorkspaceRightsQuery,
 } from "../../../lib/generated/graphql";
 import withUrqlClient from "../../../lib/withUrqlClient";
-import { CombinedError } from "urql";
 
 const PageContent = styled.section`
   flex-grow: 3;

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -21,6 +21,7 @@ import {
   useRequestingUserWorkspaceRightsQuery,
 } from "../../../lib/generated/graphql";
 import withUrqlClient from "../../../lib/withUrqlClient";
+import { CombinedError } from "urql";
 
 const PageContent = styled.section`
   flex-grow: 3;
@@ -68,7 +69,7 @@ const WorkspaceMembersPage: NextPage = () => {
   const [, changeMembership] = useChangeWorkspaceMembershipMutation();
   const [mutationError, setMutationError] = useState<{
     user: User;
-    error?: string;
+    error?: CombinedError;
   } | null>(null);
 
   const buttonCellProps = {

--- a/frontend/stubServer/resolver.js
+++ b/frontend/stubServer/resolver.js
@@ -9,6 +9,7 @@ const folderResponse = require("../cypress/fixtures/folder-graphql-response.json
 const foldersByWorkspaceResponse = require("../cypress/fixtures/folders-by-workspace-graphql-response.json");
 const getOrCreateUserResponse = require("../cypress/fixtures/get-or-create-user-graphql-response.json");
 const membersResponse = require("../cypress/fixtures/members-graphql-response.json");
+const requestingUserWorkspaceRights = require("../cypress/fixtures/requesting-user-workspace-rights.json");
 const updateFolderResponse = require("../cypress/fixtures/update-folder-graphql-response.json");
 const workspaceResponse = require("../cypress/fixtures/workspace-graphql-response.json");
 // Workspace
@@ -22,6 +23,8 @@ const workspacesResolver = {
         ? membersResponse.data.workspace.admins
         : membersResponse.data.workspace.members,
   }),
+  requestingUserWorkspaceRights: async () =>
+    requestingUserWorkspaceRights.data.requestingUserWorkspaceRights,
 };
 
 const workspaceMutation = {


### PR DESCRIPTION
this is the last bit of backend that I want to add for [AB#1820](https://dev.azure.com/futurenhs/75407963-f812-43e5-a734-1059bbc036a3/_workitems/edit/1820)

- Added in error handling
- fixed cypress test to add in workspace rights === admin which means the button will actually show up in the test to be clicked

![Screenshot 2020-11-13 at 16 51 36](https://user-images.githubusercontent.com/254647/99098159-82a1d000-25d0-11eb-9133-aa8f76d2d3f5.png)
![Screenshot 2020-11-13 at 16 52 03](https://user-images.githubusercontent.com/254647/99098198-93524600-25d0-11eb-93d8-c8f8f7f8d1ba.png)
