### PR TITLE
Show 'Make _' button only when admin

### DIFF
--- a/frontend/components/Members/MemberStatusButtonCell.test.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.test.tsx
@@ -22,6 +22,7 @@ const buttonCellProps = {
   setMutationError: (() => {}) as any,
   user,
   newRole: WorkspaceMembership.Admin,
+  isAdmin: true,
 };
 
 test("renders make admin button", () => {
@@ -43,6 +44,30 @@ test("renders make member button", () => {
         newRole={WorkspaceMembership.NonAdmin}
       />
     </ThemeProvider>
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("does not render make admin button when isAdmin status is false", () => {
+  const { asFragment } = render(
+    <MemberStatusButtonCell
+      {...buttonCellProps}
+      newRole={WorkspaceMembership.Admin}
+      isAdmin={false}
+    />
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test("does not render make member button when isAdmin status is false", () => {
+  const { asFragment } = render(
+    <MemberStatusButtonCell
+      {...buttonCellProps}
+      newRole={WorkspaceMembership.NonAdmin}
+      isAdmin={false}
+    />
   );
 
   expect(asFragment()).toMatchSnapshot();

--- a/frontend/components/Members/MemberStatusButtonCell.tsx
+++ b/frontend/components/Members/MemberStatusButtonCell.tsx
@@ -30,6 +30,7 @@ type ButtonCellProps = {
   ) => Promise<OperationResult<ChangeWorkspaceMembershipMutation>>;
   mutationError: MutationError;
   setMutationError: React.Dispatch<React.SetStateAction<MutationError>>;
+  isAdmin: boolean;
 };
 
 export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
@@ -39,28 +40,31 @@ export const MemberStatusButtonCell: FC<ButtonCellProps> = ({
   changeMembership,
   setMutationError,
   mutationError,
+  isAdmin,
 }) => (
   <>
-    <Button
-      secondary
-      onClick={async () => {
-        const result = await changeMembership({
-          input: {
-            workspace: workspaceId,
-            user: user.id,
-            newRole,
-          },
-        });
-        setMutationError({
-          user,
-          error: result.error?.message,
-        });
-      }}
-    >
-      {newRole === WorkspaceMembership.Admin
-        ? "Make Administrator"
-        : "Make Member"}
-    </Button>
+    {isAdmin && (
+      <Button
+        secondary
+        onClick={async () => {
+          const result = await changeMembership({
+            input: {
+              workspace: workspaceId,
+              user: user.id,
+              newRole,
+            },
+          });
+          setMutationError({
+            user,
+            error: result.error?.message,
+          });
+        }}
+      >
+        {newRole === WorkspaceMembership.Admin
+          ? "Make Administrator"
+          : "Make Member"}
+      </Button>
+    )}
     {mutationError?.user.id === user.id && mutationError?.error && (
       <p> Oh no... {mutationError.error} </p>
     )}

--- a/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
+++ b/frontend/components/Members/__snapshots__/MemberStatusButtonCell.test.tsx.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not render make admin button when isAdmin status is false 1`] = `<DocumentFragment />`;
+
+exports[`does not render make member button when isAdmin status is false 1`] = `<DocumentFragment />`;
+
 exports[`renders error message when user matches one in error 1`] = `
 <DocumentFragment>
   <button

--- a/frontend/pages/workspaces/[workspaceId]/members.tsx
+++ b/frontend/pages/workspaces/[workspaceId]/members.tsx
@@ -17,6 +17,7 @@ import {
   useGetWorkspaceWithMembersQuery,
   useChangeWorkspaceMembershipMutation,
   WorkspaceMembership,
+  useRequestingUserWorkspaceRightsQuery,
 } from "../../../lib/generated/graphql";
 import withUrqlClient from "../../../lib/withUrqlClient";
 
@@ -60,6 +61,15 @@ const WorkspaceMembersPage: NextPage = () => {
     variables: { id },
   });
 
+  const [workspaceRights] = useRequestingUserWorkspaceRightsQuery({
+    variables: { workspaceId: id },
+  });
+
+  const isAdmin =
+    workspaceRights.data?.requestingUserWorkspaceRights === "ADMIN"
+      ? true
+      : false;
+
   const [, changeMembership] = useChangeWorkspaceMembershipMutation();
   const [mutationError, setMutationError] = useState<{
     user: User;
@@ -71,18 +81,23 @@ const WorkspaceMembersPage: NextPage = () => {
     changeMembership,
     mutationError,
     setMutationError,
+    isAdmin,
   };
+
   const makeAdminButtonCell = (user: User) =>
     MemberStatusButtonCell({
       ...buttonCellProps,
       user,
       newRole: WorkspaceMembership.Admin,
+      isAdmin,
     });
+
   const makeNonAdminButtonCell = (user: User) =>
     MemberStatusButtonCell({
       ...buttonCellProps,
       user,
       newRole: WorkspaceMembership.NonAdmin,
+      isAdmin,
     });
 
   const workspaceTitle = (!fetching && data?.workspace.title) || "Loading...";


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/17128906/99090022-fab6c880-25c5-11eb-9b43-594e70920202.png)

Make Admin/Members button to only show when user isAdmin

<!--
Please fill out all sections that make sense for this pull request.

Feel free to remove sections, which don't apply. E.g. if the pull request doesn't contain frontend changes, you may remove the checkboxes for browser specific tests.
-->

- Ticket: AB#???
- Design: link to Figma

## Acceptance criteria

## Pre-review checklist

- [ ] Tests
- [ ] Documentation
- [ ] Analytics (user analytics, e.g. Google Analytics)
- [ ] Observability (metrics/tracing)
- [ ] Feature flag
- [ ] Data columns adhere to the [Dublin Core Metatdata schema](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). Further information is available [here](https://www.gov.uk/government/publications/recommended-open-standards-for-government/using-metadata-to-describe-data-shared-within-government)

## Testing information

- Is there any special setup required?
- Test plan?

## Test checklist

- [ ] Tested locally

- Platforms/Browsers:

  - [ ] Google Chrome (latest version)
  - [ ] Internet Explorer 11
  - [ ] Edge

- Accessibility:

  - [ ] Screen Reader
  - [ ] Keyboard Navigation
  - [ ] Magnification
  - [ ] Contrast
  - [ ] Text size 200%
  - [ ] Touch target areas (Mobile)
  - [ ] Landscape (Mobile)
